### PR TITLE
Add Isolation Forest multivariate anomaly detection (rebuild of #6)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=2.0.0
 matplotlib>=3.7.0
 seaborn>=0.12.0
+scikit-learn>=1.3.0

--- a/src/auris/audit_risk.py
+++ b/src/auris/audit_risk.py
@@ -110,6 +110,57 @@ def check_vendor_frequency(data: pd.DataFrame, config: RiskConfig = DEFAULT_CONF
     return pd.DataFrame()
 
 
+def check_ml_anomalies(data: pd.DataFrame, config: RiskConfig = DEFAULT_CONFIG) -> pd.DataFrame:
+    """Flag multivariate anomalies via Isolation Forest over (amount, vendor, date).
+
+    Imports scikit-learn lazily so the base pipeline keeps working when
+    sklearn isn't installed. Returns an empty DataFrame when the model
+    can't run (missing columns, too few rows, or sklearn unavailable).
+    """
+    required = ['amount', 'vendor', 'date']
+    if not all(col in data.columns for col in required):
+        logger.error("required columns missing for ML anomaly detection.")
+        return pd.DataFrame()
+
+    try:
+        from sklearn.ensemble import IsolationForest
+        from sklearn.preprocessing import LabelEncoder
+    except ImportError:
+        logger.warning("scikit-learn not installed; skipping ML anomaly check.")
+        return pd.DataFrame()
+
+    ml_data = data.dropna(subset=['amount']).copy()
+    if len(ml_data) < 20:
+        logger.info("not enough rows (%d) for ML anomaly detection; skipping.", len(ml_data))
+        return pd.DataFrame()
+
+    encoder = LabelEncoder()
+    ml_data['vendor_encoded'] = encoder.fit_transform(ml_data['vendor'])
+    ml_data['date_ordinal'] = pd.to_datetime(ml_data['date']).map(lambda d: d.toordinal())
+
+    features = ml_data[['amount', 'vendor_encoded', 'date_ordinal']]
+    model = IsolationForest(
+        contamination=config.ml_contamination,
+        random_state=config.ml_random_state,
+        n_estimators=config.ml_n_estimators,
+    )
+    ml_data['ml_score'] = model.fit_predict(features)
+
+    ml_anomalies = ml_data[ml_data['ml_score'] == -1].copy()
+    ml_anomalies = ml_anomalies.drop(columns=['vendor_encoded', 'date_ordinal', 'ml_score'])
+
+    if not ml_anomalies.empty:
+        ml_anomalies['risk_type'] = 'ML Anomaly'
+        logger.info(
+            "ML-detected anomalies (Isolation Forest): %d (contamination=%.2f)",
+            len(ml_anomalies), config.ml_contamination,
+        )
+        logger.debug("ml anomalies:\n%s", ml_anomalies.head(10))
+    else:
+        logger.info("no ML anomalies detected.")
+    return ml_anomalies
+
+
 def check_amount_deviation(data: pd.DataFrame, config: RiskConfig = DEFAULT_CONFIG) -> pd.DataFrame:
     """Flag transactions whose amount falls outside the configured per-vendor band."""
     if 'amount' not in data.columns:
@@ -228,9 +279,20 @@ def generate_report(
     frequent_vendors: pd.DataFrame,
     amount_deviations: pd.DataFrame,
     output_dir: Path,
+    ml_anomalies: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
-    """Concatenate every per-check DataFrame and write the consolidated risks_report.csv."""
-    report = pd.concat([duplicates, anomalies, missing, frequent_vendors, amount_deviations], ignore_index=True)
+    """Concatenate every per-check DataFrame and write the consolidated risks_report.csv.
+
+    ml_anomalies is an optional sixth frame (from check_ml_anomalies). When
+    omitted, the report shape stays identical to the original five-check
+    pipeline so existing call sites and tests continue to work.
+    """
+    if ml_anomalies is None:
+        ml_anomalies = pd.DataFrame()
+    report = pd.concat(
+        [duplicates, anomalies, missing, frequent_vendors, amount_deviations, ml_anomalies],
+        ignore_index=True,
+    )
     if not report.empty:
         report = report.sort_values(['risk_type', 'vendor', 'amount', 'date'])
         report.to_csv(output_dir / 'risks_report.csv', index=False)
@@ -256,6 +318,14 @@ def parse_args() -> argparse.Namespace:
                         help="Per-vendor low-end multiplier for amount deviation (default 0.2)")
     parser.add_argument("--deviation-high", type=float, default=DEFAULT_CONFIG.deviation_high_multiplier,
                         help="Per-vendor high-end multiplier for amount deviation (default 2.0)")
+    parser.add_argument("--enable-ml", action="store_true",
+                        help="Also run Isolation Forest multivariate anomaly detection")
+    parser.add_argument("--ml-contamination", type=float, default=DEFAULT_CONFIG.ml_contamination,
+                        help="Expected fraction of outliers for Isolation Forest (default 0.05)")
+    parser.add_argument("--ml-n-estimators", type=int, default=DEFAULT_CONFIG.ml_n_estimators,
+                        help="Number of trees in the Isolation Forest (default 200)")
+    parser.add_argument("--ml-random-state", type=int, default=DEFAULT_CONFIG.ml_random_state,
+                        help="Random seed for deterministic ML runs (default 42)")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Increase verbosity (-v for DEBUG)")
     parser.add_argument("-q", "--quiet", action="count", default=0,
@@ -275,6 +345,9 @@ def main() -> None:
         vendor_frequency_quantile=args.vendor_frequency_quantile,
         deviation_low_multiplier=args.deviation_low,
         deviation_high_multiplier=args.deviation_high,
+        ml_contamination=args.ml_contamination,
+        ml_n_estimators=args.ml_n_estimators,
+        ml_random_state=args.ml_random_state,
     )
 
     logger.info("starting AuRIS: Audit Risk Identification System")
@@ -286,7 +359,11 @@ def main() -> None:
     missing = check_missing(data)
     frequent_vendors = check_vendor_frequency(data, config)
     amount_deviations = check_amount_deviation(data, config)
-    report = generate_report(duplicates, anomalies, missing, frequent_vendors, amount_deviations, output_dir)
+    ml_anomalies = check_ml_anomalies(data, config) if args.enable_ml else None
+    report = generate_report(
+        duplicates, anomalies, missing, frequent_vendors, amount_deviations, output_dir,
+        ml_anomalies=ml_anomalies,
+    )
     plot_histogram(data, output_dir)
     plot_vendor_frequency(data, output_dir)
     plot_time_series(data, output_dir)

--- a/src/auris/config.py
+++ b/src/auris/config.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class RiskConfig:
-    """Thresholds for the five statistical risk checks.
+    """Thresholds for the statistical and ML risk checks.
 
     Attributes:
         anomaly_quantile: Quantile of `amount` above which a row is flagged
@@ -20,12 +20,20 @@ class RiskConfig:
             is below `mean * this` are flagged. Default 0.2 (<20% of mean).
         deviation_high_multiplier: Per-vendor multiplier; rows whose amount
             is above `mean * this` are flagged. Default 2.0 (>200% of mean).
+        ml_contamination: Expected fraction of outliers for Isolation Forest.
+            Default 0.05 (about 5% of rows flagged).
+        ml_n_estimators: Number of trees in the Isolation Forest ensemble.
+            Default 200.
+        ml_random_state: Random seed for deterministic ML runs. Default 42.
     """
 
     anomaly_quantile: float = 0.9
     vendor_frequency_quantile: float = 0.9
     deviation_low_multiplier: float = 0.2
     deviation_high_multiplier: float = 2.0
+    ml_contamination: float = 0.05
+    ml_n_estimators: int = 200
+    ml_random_state: int = 42
 
 
 DEFAULT_CONFIG = RiskConfig()

--- a/tests/test_ml_anomalies.py
+++ b/tests/test_ml_anomalies.py
@@ -1,0 +1,84 @@
+"""Behavior tests for the Isolation Forest ML anomaly check."""
+import pandas as pd
+import pytest
+
+from auris.audit_risk import check_ml_anomalies, generate_report
+from auris.config import RiskConfig
+
+
+@pytest.fixture
+def ml_sample() -> pd.DataFrame:
+    """50 normal rows around amount=100 plus 3 obvious multivariate outliers.
+
+    Rows 1-50 are clustered tightly. The last three (51-53) have amounts
+    several orders of magnitude larger than the cluster, so a seeded
+    Isolation Forest should flag them with high confidence.
+    """
+    normal = [
+        {"invoice_id": i, "vendor": ["A", "B", "C"][i % 3], "amount": 100.0 + (i % 10),
+         "date": f"2025-01-{(i % 28) + 1:02d}"}
+        for i in range(1, 51)
+    ]
+    outliers = [
+        {"invoice_id": 51, "vendor": "A", "amount": 99999.0, "date": "2025-01-15"},
+        {"invoice_id": 52, "vendor": "B", "amount": 50000.0, "date": "2025-01-16"},
+        {"invoice_id": 53, "vendor": "C", "amount": 75000.0, "date": "2025-01-17"},
+    ]
+    return pd.DataFrame(normal + outliers)
+
+
+def test_check_ml_anomalies_flags_outliers(ml_sample):
+    """Seeded Isolation Forest should flag the planted outliers."""
+    result = check_ml_anomalies(ml_sample)
+    assert not result.empty
+    assert (result["risk_type"] == "ML Anomaly").all()
+    flagged_ids = set(result["invoice_id"])
+    planted_outliers = {51, 52, 53}
+    assert planted_outliers.issubset(flagged_ids), (
+        f"expected planted outliers {planted_outliers} flagged, got {flagged_ids}"
+    )
+
+
+def test_check_ml_anomalies_is_deterministic(ml_sample):
+    """Two runs with the same random_state produce the same flagged ids."""
+    first = check_ml_anomalies(ml_sample)
+    second = check_ml_anomalies(ml_sample)
+    assert set(first["invoice_id"]) == set(second["invoice_id"])
+
+
+def test_check_ml_anomalies_respects_contamination(ml_sample):
+    """Higher contamination flags at least as many rows as lower."""
+    sparse = check_ml_anomalies(ml_sample, RiskConfig(ml_contamination=0.02))
+    dense = check_ml_anomalies(ml_sample, RiskConfig(ml_contamination=0.20))
+    assert len(dense) >= len(sparse)
+
+
+def test_check_ml_anomalies_missing_columns_returns_empty():
+    df = pd.DataFrame([{"vendor": "A", "date": "2025-01-01"}])
+    assert check_ml_anomalies(df).empty
+
+
+def test_check_ml_anomalies_too_few_rows_returns_empty():
+    df = pd.DataFrame([
+        {"invoice_id": i, "vendor": "A", "amount": 100.0, "date": "2025-01-01"}
+        for i in range(5)
+    ])
+    assert check_ml_anomalies(df).empty
+
+
+def test_generate_report_includes_ml_anomalies(tmp_path, ml_sample):
+    """generate_report concatenates ml_anomalies when provided."""
+    empty = pd.DataFrame()
+    ml = check_ml_anomalies(ml_sample)
+    report = generate_report(empty, empty, empty, empty, empty, tmp_path, ml_anomalies=ml)
+    assert (tmp_path / "risks_report.csv").exists()
+    assert "ML Anomaly" in set(report["risk_type"].unique())
+
+
+def test_generate_report_backward_compatible_without_ml(tmp_path):
+    """Original five-arg signature still works without ml_anomalies."""
+    empty = pd.DataFrame()
+    one_row = pd.DataFrame([{"invoice_id": 1, "vendor": "A", "amount": 100,
+                             "date": "2025-01-01", "risk_type": "Duplicate"}])
+    report = generate_report(one_row, empty, empty, empty, empty, tmp_path)
+    assert set(report["risk_type"].unique()) == {"Duplicate"}


### PR DESCRIPTION
## Summary
Clean rebuild of closed PR #6 on top of the new project structure (PR #5) and the type/logging/config/test scaffolding from PR #8.

## What's in
- New `check_ml_anomalies()` in `src/auris/audit_risk.py` runs Isolation Forest over `(amount, vendor_encoded, date_ordinal)`.
- Three new `RiskConfig` fields: `ml_contamination`, `ml_n_estimators`, `ml_random_state`. Seeded `random_state` keeps runs deterministic.
- Four new CLI flags: `--enable-ml`, `--ml-contamination`, `--ml-n-estimators`, `--ml-random-state`.
- `--enable-ml` is opt-in. Without it, the pipeline produces byte-identical output to current main (zero regression risk for existing users).
- `generate_report` gains an optional `ml_anomalies` kwarg defaulting to an empty frame, so the original five-arg signature still works for the existing tests.
- `sklearn` imports are lazy inside `check_ml_anomalies` so the base pipeline keeps working when scikit-learn isn't installed (warning is logged).
- scikit-learn added to `requirements.txt`.

## Tests
7 new tests in `tests/test_ml_anomalies.py`:
- Planted outliers in a 53-row fixture get flagged.
- Determinism: two runs with the same `random_state` produce identical flags.
- Contamination sensitivity: higher value flags at least as many rows.
- Graceful failure on missing required columns.
- Graceful failure on fewer than 20 rows.
- `generate_report` concatenates `ml_anomalies` when provided.
- `generate_report` remains backward-compatible without `ml_anomalies`.

Full suite: 18 passing locally in ~2s.

## Test plan
- [ ] CI passes on Python 3.10, 3.11, 3.12.
- [ ] `python3 -m pytest tests/ -v` locally.
- [ ] `python3 -m auris -i data/transactions.csv -o output` runs unchanged (no `--enable-ml`).
- [ ] `python3 -m auris -i data/transactions.csv -o output --enable-ml -v` adds `ML Anomaly` rows to `risks_report.csv`.