### PR TITLE
Harden .gitignore against secrets and local context leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,50 @@
+# Virtual environments
 venv/
 .venv/
+env/
 
+# Python bytecode and caches
 *.pyc
 __pycache__/
 .pytest_cache/
+.mypy_cache/
+.ruff_cache/
 
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Logs and temp files
 *.log
-.DS_Store
-
 *.bak
 *.tmp
+*.swp
+*.swo
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Secrets and local configuration
+.env
+.env.*
+*.env
+.envrc
+secrets.json
+credentials.json
+*.key
+*.pem
+
+# Local Claude / agent context (machine-specific, contains personal context)
+CLAUDE.md
+.claude/
+
+# Editor and IDE
+.idea/
+.vscode/
 
 # Generated outputs
 output/*.png
 output/*.csv
+output/*.md


### PR DESCRIPTION
## Summary
- Protects against accidentally committing env / secrets files (\`.env\`, \`.env.*\`, \`.envrc\`, \`*.key\`, \`*.pem\`, \`secrets.json\`, \`credentials.json\`). Required before the Level 1 Claude summary layer introduces the \`ANTHROPIC_API_KEY\` env var.
- Ignores the machine-local \`CLAUDE.md\` project-context file and \`.claude/\` agent settings directory, which carry per-user context that should never reach the public repo.
- Ignores generated \`output/risk_summary.md\` files alongside the existing PNG and CSV exclusions.
- Reorganises existing entries into labelled sections and adds common editor cruft (\`.idea/\`, \`.vscode/\`, vim swap files) plus extra Python tool caches (\`.mypy_cache\`, \`.ruff_cache\`).

No existing tracked file is newly ignored, so this change is a pure addition to the protected surface.

## Test plan
- [ ] Confirm \`git check-ignore -v CLAUDE.md .env secrets.json output/risk_summary.md\` returns the matching gitignore line for each.
- [ ] Confirm \`git status\` after merge still treats \`data/transactions.csv\` and the rest of the tracked tree as expected.
- [ ] Confirm CI is green on this branch.