### PR TITLE
Add Claude summary layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,49 @@ Isolation Forest over `(amount, vendor_encoded, date_ordinal)`, seeded for deter
 Enable via `--enable-ml`. Tunable via `--ml-contamination` (default `0.05`), `--ml-n-estimators` (default `200`), `--ml-random-state` (default `42`).
 Output: `risk_type = 'ML Anomaly'`.
 
+## AI-Augmented Summaries
+
+On top of the six risk checks, AuRIS can generate a CFO-readable Markdown summary of the flagged transactions using the Claude API. This is opt-in and entirely separate from the statistical pipeline, so the engine itself never depends on a network call.
+
+### How it works
+
+`src/auris/summarize.py` exposes `summarize_risks(report, config)`. It groups the risk report by `risk_type`, takes the top 5 highest-amount rows from each group, and sends that compact projection to Claude (default model: `claude-haiku-4-5`, the cheapest tier). The response is a Markdown document with a 3-5 bullet executive summary plus one paragraph per risk type. Empty reports short-circuit with a canned "no risks found" message and do not call the API.
+
+### Setup
+
+1. Get an API key at [platform.claude.com](https://platform.claude.com).
+2. Set it as an environment variable, or create a `.env` file at the repo root:
+   ```bash
+   echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env
+   export ANTHROPIC_API_KEY=sk-ant-...
+   ```
+3. Install the SDK (already in `requirements.txt`):
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+The `.env` file and any `*.key` / `secrets.json` are gitignored. Never commit your API key.
+
+### CLI usage
+
+```bash
+python3 -m auris -i data/transactions.csv -o output --summarize -v
+```
+
+When `--summarize` is set, after the regular pipeline finishes AuRIS writes `output/risk_summary.md` alongside `risks_report.csv` and the five PNG plots. Override the model or token cap with `--summary-model` and `--summary-max-tokens`.
+
+### Streamlit usage
+
+Launch the dashboard as usual:
+```bash
+streamlit run app.py
+```
+Under the "AI Executive Summary" section there is a **Generate AI Summary** button. Click it, the summary is generated, rendered as Markdown, and offered as a Markdown download.
+
+### Cost
+
+A single summary call is typically a few thousand input tokens and under 1024 output tokens, costing roughly $0.005 to $0.01 with Haiku 4.5 (input $1 / M tokens, output $5 / M tokens). All tests use a mocked Anthropic client, so CI does not require an API key and incurs no cost.
+
 ## Visualizations
 
 Five PNG plots written to the output directory on every run:
@@ -141,6 +184,8 @@ class RiskConfig:
     ml_contamination: float = 0.05
     ml_n_estimators: int = 200
     ml_random_state: int = 42
+    summary_model: str = "claude-haiku-4-5"
+    summary_max_tokens: int = 1024
 ```
 
 Every field is exposed three ways: as a CLI flag, as a Streamlit slider, and as a dataclass argument when using AuRIS as a library.
@@ -152,9 +197,10 @@ pip install -r requirements-dev.txt
 python3 -m pytest tests/ -v
 ```
 
-18 pytest tests cover the six risk checks, the report shape, and the ML pass:
+23 pytest tests cover the six risk checks, the report shape, the ML pass, and the AI summary layer:
 - `tests/test_audit_risk.py`, 11 tests on the statistical checks.
 - `tests/test_ml_anomalies.py`, 7 tests on the Isolation Forest pass.
+- `tests/test_summarize.py`, 5 tests on the Claude summary layer (all mocked, no API calls).
 
 GitHub Actions runs the full test suite against Python 3.10, 3.11, and 3.12 on every push and pull request to `main` and `dev`. See `.github/workflows/ci.yml`.
 
@@ -208,7 +254,7 @@ AuRIS/
 
 AuRIS is being built up in five public, shippable levels. Each level is a separate PR, leaves the existing test suite green, and adds a new capability without rewriting the engine.
 
-1. **AI summary layer.** Add a Claude-powered natural-language risk summary, opt-in via `--summarize`, surfaced as a "Generate AI Summary" button in the Streamlit dashboard.
+1. **AI summary layer.** Shipped. Claude-powered natural-language risk summary, opt-in via `--summarize`, surfaced as a "Generate AI Summary" button in the Streamlit dashboard. See [AI-Augmented Summaries](#ai-augmented-summaries) above.
 2. **Risk scoring engine.** Replace binary flags with a 0-100 numeric risk score per row plus explicit reason codes, weighted across all six checks.
 3. **Full-stack conversion.** FastAPI backend wrapping the Python engine, Next.js 15 + TypeScript + shadcn frontend, deployed to Vercel and Railway with a live demo URL.
 4. **Persistence, auth, and run history.** Supabase Postgres for multi-tenant run storage, magic-link auth, sharable read-only run URLs, and a side-by-side run comparison view.

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from auris.audit_risk import (
     check_vendor_frequency,
 )
 from auris.config import RiskConfig
+from auris.summarize import summarize_risks
 
 DEFAULT_CSV = PROJECT_ROOT / "data" / "transactions.csv"
 
@@ -87,6 +88,30 @@ checks = [
 ]
 for col, (name, df) in zip(risk_cols, checks):
     col.metric(name, len(df))
+
+# AI-generated executive summary (opt-in, requires ANTHROPIC_API_KEY).
+st.subheader("AI Executive Summary")
+st.caption(
+    "Generate a CFO-readable Markdown summary of the flagged risks using Claude. "
+    "Requires ANTHROPIC_API_KEY in the environment. Cost is typically under one cent per call."
+)
+if st.button("Generate AI Summary"):
+    with st.spinner("Asking Claude to summarise the risks..."):
+        try:
+            summary_md = summarize_risks(report, config)
+            st.session_state["risk_summary_md"] = summary_md
+        except RuntimeError as exc:
+            st.error(str(exc))
+        except Exception as exc:
+            st.error(f"Failed to generate summary: {exc}")
+if "risk_summary_md" in st.session_state:
+    st.markdown(st.session_state["risk_summary_md"])
+    st.download_button(
+        "Download summary as Markdown",
+        st.session_state["risk_summary_md"],
+        "risk_summary.md",
+        "text/markdown",
+    )
 
 # Filterable report table with CSV download.
 if not report.empty:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=2.0.0
 matplotlib>=3.7.0
 seaborn>=0.12.0
 scikit-learn>=1.3.0
+anthropic>=0.40

--- a/src/auris/audit_risk.py
+++ b/src/auris/audit_risk.py
@@ -326,6 +326,13 @@ def parse_args() -> argparse.Namespace:
                         help="Number of trees in the Isolation Forest (default 200)")
     parser.add_argument("--ml-random-state", type=int, default=DEFAULT_CONFIG.ml_random_state,
                         help="Random seed for deterministic ML runs (default 42)")
+    parser.add_argument("--summarize", action="store_true",
+                        help="Generate a Claude-written executive summary of the report "
+                             "(requires ANTHROPIC_API_KEY); writes risk_summary.md")
+    parser.add_argument("--summary-model", type=str, default=DEFAULT_CONFIG.summary_model,
+                        help="Claude model id for the AI summary (default claude-haiku-4-5)")
+    parser.add_argument("--summary-max-tokens", type=int, default=DEFAULT_CONFIG.summary_max_tokens,
+                        help="Max tokens for the AI summary output (default 1024)")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Increase verbosity (-v for DEBUG)")
     parser.add_argument("-q", "--quiet", action="count", default=0,
@@ -348,6 +355,8 @@ def main() -> None:
         ml_contamination=args.ml_contamination,
         ml_n_estimators=args.ml_n_estimators,
         ml_random_state=args.ml_random_state,
+        summary_model=args.summary_model,
+        summary_max_tokens=args.summary_max_tokens,
     )
 
     logger.info("starting AuRIS: Audit Risk Identification System")
@@ -369,6 +378,16 @@ def main() -> None:
     plot_time_series(data, output_dir)
     plot_risk_distribution(report, output_dir)
     plot_vendor_date_heatmap(data, output_dir)
+
+    if args.summarize:
+        from auris.summarize import summarize_risks
+        try:
+            summary_md = summarize_risks(report, config)
+            (output_dir / "risk_summary.md").write_text(summary_md, encoding="utf-8")
+            logger.info("AI summary saved as risk_summary.md")
+        except (RuntimeError, ValueError) as exc:
+            logger.error("AI summary skipped: %s", exc)
+
     logger.info("AuRIS analysis complete!")
 
 

--- a/src/auris/config.py
+++ b/src/auris/config.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class RiskConfig:
-    """Thresholds for the statistical and ML risk checks.
+    """Thresholds for the statistical, ML, and AI-summary risk checks.
 
     Attributes:
         anomaly_quantile: Quantile of `amount` above which a row is flagged
@@ -25,6 +25,11 @@ class RiskConfig:
         ml_n_estimators: Number of trees in the Isolation Forest ensemble.
             Default 200.
         ml_random_state: Random seed for deterministic ML runs. Default 42.
+        summary_model: Claude model id used by the AI summary layer.
+            Default "claude-haiku-4-5" (cheapest tier, sufficient for short
+            executive summaries).
+        summary_max_tokens: Hard cap on summary output length in tokens.
+            Default 1024 (keeps cost predictable; one CFO-readable summary).
     """
 
     anomaly_quantile: float = 0.9
@@ -34,6 +39,8 @@ class RiskConfig:
     ml_contamination: float = 0.05
     ml_n_estimators: int = 200
     ml_random_state: int = 42
+    summary_model: str = "claude-haiku-4-5"
+    summary_max_tokens: int = 1024
 
 
 DEFAULT_CONFIG = RiskConfig()

--- a/src/auris/summarize.py
+++ b/src/auris/summarize.py
@@ -1,0 +1,111 @@
+"""Claude-powered natural-language summaries of an AuRIS risk report.
+
+Reads `ANTHROPIC_API_KEY` from the environment, sends a compact projection
+of the risk report (top-N highest-amount rows per `risk_type`) to the
+Anthropic API, and returns a CFO-readable Markdown summary.
+
+Designed for cost: the prompt is bounded by `_TOP_N_PER_TYPE * num_risk_types`
+rows regardless of input size, and the output is capped via
+`RiskConfig.summary_max_tokens`. Empty reports short-circuit without
+calling the API at all.
+"""
+import logging
+import os
+from typing import Optional
+
+import pandas as pd
+
+from auris.config import DEFAULT_CONFIG, RiskConfig
+
+logger = logging.getLogger("auris")
+
+_TOP_N_PER_TYPE = 5
+_EMPTY_REPORT_MESSAGE = (
+    "# AuRIS Risk Summary\n\n"
+    "No risks were detected in the analysed transactions. "
+    "All checks passed under the current thresholds.\n"
+)
+_SYSTEM_PROMPT = (
+    "You are a senior audit analyst writing executive summaries for a CFO. "
+    "You will receive a risk report grouped by risk_type. Each group shows the "
+    "highest-amount transactions flagged by that check.\n\n"
+    "Produce a Markdown document with this exact structure:\n"
+    "1. A top-level heading: `# AuRIS Risk Summary`\n"
+    "2. A 3 to 5 bullet executive summary under `## Executive Summary`\n"
+    "3. One short paragraph per risk_type under `## Findings by Risk Type`, "
+    "each prefixed with a `### <risk_type>` subheading, explaining what was "
+    "flagged and why it warrants review.\n\n"
+    "Be concise, factual, and CFO-readable. Do not invent transactions; only "
+    "describe what is in the report. Do not include preamble or closing notes."
+)
+
+
+def _build_prompt(report: pd.DataFrame) -> str:
+    """Build the user-message body from the top-N rows per risk_type."""
+    sections: list[str] = []
+    for risk_type, group in report.groupby("risk_type"):
+        top_rows = group.nlargest(_TOP_N_PER_TYPE, "amount", keep="first")
+        sections.append(f"## {risk_type} ({len(group)} total rows flagged)")
+        sections.append(
+            "Top {n} by amount:".format(n=min(_TOP_N_PER_TYPE, len(group)))
+        )
+        for _, row in top_rows.iterrows():
+            vendor = row.get("vendor", "unknown")
+            amount = row.get("amount", "n/a")
+            date = row.get("date", "n/a")
+            sections.append(f"- vendor={vendor}, amount={amount}, date={date}")
+        sections.append("")
+    return "\n".join(sections).strip()
+
+
+def summarize_risks(
+    report: pd.DataFrame,
+    config: RiskConfig = DEFAULT_CONFIG,
+    client: Optional[object] = None,
+) -> str:
+    """Generate a Markdown executive summary of the risk report via Claude.
+
+    Returns a canned no-risk message and does not hit the API when the
+    report is empty. Raises RuntimeError if `ANTHROPIC_API_KEY` is unset.
+    `client` is an optional pre-built Anthropic client, useful for tests.
+    """
+    if report is None or report.empty:
+        logger.info("risk report is empty; skipping API call.")
+        return _EMPTY_REPORT_MESSAGE
+
+    if "risk_type" not in report.columns:
+        raise ValueError("report must include a 'risk_type' column.")
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY environment variable is required for the "
+            "summary feature. Get a key from platform.claude.com and set it "
+            "in your environment (e.g. via a .env file)."
+        )
+
+    if client is None:
+        import anthropic
+        client = anthropic.Anthropic()
+
+    user_prompt = _build_prompt(report)
+    logger.info(
+        "requesting AI summary: model=%s, max_tokens=%d, prompt_chars=%d",
+        config.summary_model, config.summary_max_tokens, len(user_prompt),
+    )
+
+    response = client.messages.create(
+        model=config.summary_model,
+        max_tokens=config.summary_max_tokens,
+        system=_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+
+    for block in response.content:
+        if getattr(block, "type", None) == "text":
+            text = block.text.strip()
+            if text:
+                return text
+
+    logger.warning("AI summary response contained no text block; returning empty message.")
+    return _EMPTY_REPORT_MESSAGE

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,0 +1,111 @@
+"""Tests for the Claude-powered AI summary layer.
+
+All tests use a mocked Anthropic client; no real API calls are made,
+so CI does not require ANTHROPIC_API_KEY.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from auris.config import RiskConfig
+from auris.summarize import _EMPTY_REPORT_MESSAGE, summarize_risks
+
+
+def _fake_anthropic_response(text: str) -> SimpleNamespace:
+    """Mimic the shape of an anthropic.types.Message: content is a list of blocks."""
+    text_block = SimpleNamespace(type="text", text=text)
+    return SimpleNamespace(content=[text_block])
+
+
+def _mock_client(reply_text: str = "# AuRIS Risk Summary\n\nSummary body.") -> MagicMock:
+    """Build a MagicMock Anthropic client whose messages.create returns reply_text."""
+    client = MagicMock()
+    client.messages.create.return_value = _fake_anthropic_response(reply_text)
+    return client
+
+
+@pytest.fixture
+def small_report() -> pd.DataFrame:
+    """A 4-row report covering 3 risk types with realistic columns."""
+    return pd.DataFrame([
+        {"invoice_id": 1, "vendor": "A", "amount": 100.0, "date": "2025-01-01", "risk_type": "Duplicate"},
+        {"invoice_id": 2, "vendor": "A", "amount": 100.0, "date": "2025-01-01", "risk_type": "Duplicate"},
+        {"invoice_id": 3, "vendor": "D", "amount": 9999.0, "date": "2025-01-11", "risk_type": "Anomaly"},
+        {"invoice_id": 4, "vendor": "C", "amount": float("nan"), "date": "2025-01-10", "risk_type": "Missing Data"},
+    ])
+
+
+def test_summarize_risks_happy_path_calls_anthropic_with_expected_args(
+    monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
+) -> None:
+    """Mock the Anthropic client and verify model, max_tokens, and prompt contents."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    client = _mock_client("# AuRIS Risk Summary\n\n- Found duplicates and one anomaly.")
+
+    result = summarize_risks(small_report, RiskConfig(), client=client)
+
+    assert client.messages.create.call_count == 1
+    kwargs = client.messages.create.call_args.kwargs
+    assert kwargs["model"] == "claude-haiku-4-5"
+    assert kwargs["max_tokens"] == 1024
+    assert kwargs["system"].startswith("You are a senior audit analyst")
+    user_prompt = kwargs["messages"][0]["content"]
+    assert "Duplicate" in user_prompt
+    assert "Anomaly" in user_prompt
+    assert "Missing Data" in user_prompt
+    assert "9999" in user_prompt
+    assert result.startswith("# AuRIS Risk Summary")
+
+
+def test_summarize_risks_empty_report_returns_canned_message_without_api_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty report short-circuits: returns the canned message, never hits the API."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    client = _mock_client()
+
+    result = summarize_risks(pd.DataFrame(), RiskConfig(), client=client)
+
+    assert result == _EMPTY_REPORT_MESSAGE
+    assert client.messages.create.call_count == 0
+
+
+def test_summarize_risks_missing_api_key_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
+) -> None:
+    """When ANTHROPIC_API_KEY is unset, raise RuntimeError with a clear message."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+        summarize_risks(small_report, RiskConfig())
+
+
+def test_summarize_risks_respects_custom_model_and_max_tokens(
+    monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
+) -> None:
+    """RiskConfig overrides for summary_model and summary_max_tokens are honoured."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    client = _mock_client()
+    config = RiskConfig(summary_model="claude-sonnet-4-6", summary_max_tokens=2048)
+
+    summarize_risks(small_report, config, client=client)
+
+    kwargs = client.messages.create.call_args.kwargs
+    assert kwargs["model"] == "claude-sonnet-4-6"
+    assert kwargs["max_tokens"] == 2048
+
+
+def test_summarize_risks_returns_non_empty_markdown_string(
+    monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
+) -> None:
+    """The function returns a non-empty string that looks like Markdown."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    client = _mock_client("# Heading\n\n- bullet 1\n- bullet 2\n")
+
+    result = summarize_risks(small_report, RiskConfig(), client=client)
+
+    assert isinstance(result, str)
+    assert len(result) > 0
+    assert result.startswith("#")


### PR DESCRIPTION
## Summary
- Adds an AI-augmented executive summary on top of the existing six risk checks. Opt-in via \`--summarize\` on the CLI and a "Generate AI Summary" button in the Streamlit dashboard. Both write Markdown (CLI to \`output/risk_summary.md\`, dashboard renders inline + offers download).
- New module \`src/auris/summarize.py\` exposes \`summarize_risks(report, config) -> str\`. Reads \`ANTHROPIC_API_KEY\` from the environment; empty reports short-circuit with a canned message and never call the API.
- Default model is \`claude-haiku-4-5\` (cheapest tier). Input is bounded to the top 5 highest-amount rows per \`risk_type\` (~30 rows regardless of dataset size). Output is capped at 1024 tokens. Expected per-call cost: roughly \$0.005 to \$0.01.
- \`RiskConfig\` gains two backward-compatible fields (\`summary_model\`, \`summary_max_tokens\`). All existing \`RiskConfig()\` call sites keep working.
- 5 new mocked tests in \`tests/test_summarize.py\`: happy path, empty report, missing API key, custom model/token cap, output shape. No real API calls. Test count goes from 18 to 23.

## Test plan
- [ ] CI: \`pytest\` matrix green on Python 3.10 / 3.11 / 3.12 with all 23 tests passing.
- [ ] Local with \`ANTHROPIC_API_KEY\` set: \`python -m auris -i data/transactions.csv -o output --summarize -v\` writes a sensible \`output/risk_summary.md\`.
- [ ] Local Streamlit: \`streamlit run app.py\`, click "Generate AI Summary", confirm Markdown renders and downloads cleanly.
- [ ] Confirm empty-report path: a synthetic clean CSV runs through \`--summarize\` and writes the canned no-risks summary without spending any tokens.