### PR TITLE
Swap AI summary provider from Claude to Google Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ Output: `risk_type = 'ML Anomaly'`.
 
 ## AI-Augmented Summaries
 
-On top of the six risk checks, AuRIS can generate a CFO-readable Markdown summary of the flagged transactions using the Claude API. This is opt-in and entirely separate from the statistical pipeline, so the engine itself never depends on a network call.
+On top of the six risk checks, AuRIS can generate a CFO-readable Markdown summary of the flagged transactions using the Google Gemini API. This is opt-in and entirely separate from the statistical pipeline, so the engine itself never depends on a network call.
 
 ### How it works
 
-`src/auris/summarize.py` exposes `summarize_risks(report, config)`. It groups the risk report by `risk_type`, takes the top 5 highest-amount rows from each group, and sends that compact projection to Claude (default model: `claude-haiku-4-5`, the cheapest tier). The response is a Markdown document with a 3-5 bullet executive summary plus one paragraph per risk type. Empty reports short-circuit with a canned "no risks found" message and do not call the API.
+`src/auris/summarize.py` exposes `summarize_risks(report, config)`. It groups the risk report by `risk_type`, takes the top 5 highest-amount rows from each group, and sends that compact projection to Gemini (default model: `gemini-2.0-flash-001`, free tier). The response is a Markdown document with a 3-5 bullet executive summary plus one paragraph per risk type. Empty reports short-circuit with a canned "no risks found" message and do not call the API.
 
 ### Setup
 
-1. Get an API key at [platform.claude.com](https://platform.claude.com).
+1. Get a free API key at [aistudio.google.com/apikey](https://aistudio.google.com/apikey). No credit card required.
 2. Set it as an environment variable, or create a `.env` file at the repo root:
    ```bash
-   echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env
-   export ANTHROPIC_API_KEY=sk-ant-...
+   echo 'GOOGLE_API_KEY=AIza...' > .env
+   export GOOGLE_API_KEY=AIza...
    ```
 3. Install the SDK (already in `requirements.txt`):
    ```bash
@@ -85,7 +85,7 @@ Under the "AI Executive Summary" section there is a **Generate AI Summary** butt
 
 ### Cost
 
-A single summary call is typically a few thousand input tokens and under 1024 output tokens, costing roughly $0.005 to $0.01 with Haiku 4.5 (input $1 / M tokens, output $5 / M tokens). All tests use a mocked Anthropic client, so CI does not require an API key and incurs no cost.
+Gemini 2.0 Flash has a generous free tier (1,500 requests per day, 1M tokens per minute of input). A typical summary call is a few thousand input tokens and under 1024 output tokens, so normal development and demo usage costs nothing. All tests use a mocked Gemini client, so CI does not require an API key and incurs no cost.
 
 ## Visualizations
 
@@ -184,7 +184,7 @@ class RiskConfig:
     ml_contamination: float = 0.05
     ml_n_estimators: int = 200
     ml_random_state: int = 42
-    summary_model: str = "claude-haiku-4-5"
+    summary_model: str = "gemini-2.0-flash-001"
     summary_max_tokens: int = 1024
 ```
 
@@ -200,7 +200,7 @@ python3 -m pytest tests/ -v
 23 pytest tests cover the six risk checks, the report shape, the ML pass, and the AI summary layer:
 - `tests/test_audit_risk.py`, 11 tests on the statistical checks.
 - `tests/test_ml_anomalies.py`, 7 tests on the Isolation Forest pass.
-- `tests/test_summarize.py`, 5 tests on the Claude summary layer (all mocked, no API calls).
+- `tests/test_summarize.py`, 5 tests on the Gemini summary layer (all mocked, no API calls).
 
 GitHub Actions runs the full test suite against Python 3.10, 3.11, and 3.12 on every push and pull request to `main` and `dev`. See `.github/workflows/ci.yml`.
 
@@ -254,7 +254,7 @@ AuRIS/
 
 AuRIS is being built up in five public, shippable levels. Each level is a separate PR, leaves the existing test suite green, and adds a new capability without rewriting the engine.
 
-1. **AI summary layer.** Shipped. Claude-powered natural-language risk summary, opt-in via `--summarize`, surfaced as a "Generate AI Summary" button in the Streamlit dashboard. See [AI-Augmented Summaries](#ai-augmented-summaries) above.
+1. **AI summary layer.** Shipped. Gemini-powered natural-language risk summary, opt-in via `--summarize`, surfaced as a "Generate AI Summary" button in the Streamlit dashboard. See [AI-Augmented Summaries](#ai-augmented-summaries) above.
 2. **Risk scoring engine.** Replace binary flags with a 0-100 numeric risk score per row plus explicit reason codes, weighted across all six checks.
 3. **Full-stack conversion.** FastAPI backend wrapping the Python engine, Next.js 15 + TypeScript + shadcn frontend, deployed to Vercel and Railway with a live demo URL.
 4. **Persistence, auth, and run history.** Supabase Postgres for multi-tenant run storage, magic-link auth, sharable read-only run URLs, and a side-by-side run comparison view.

--- a/app.py
+++ b/app.py
@@ -89,14 +89,15 @@ checks = [
 for col, (name, df) in zip(risk_cols, checks):
     col.metric(name, len(df))
 
-# AI-generated executive summary (opt-in, requires ANTHROPIC_API_KEY).
+# AI-generated executive summary (opt-in, requires GOOGLE_API_KEY).
 st.subheader("AI Executive Summary")
 st.caption(
-    "Generate a CFO-readable Markdown summary of the flagged risks using Claude. "
-    "Requires ANTHROPIC_API_KEY in the environment. Cost is typically under one cent per call."
+    "Generate a CFO-readable Markdown summary of the flagged risks using Google Gemini. "
+    "Requires GOOGLE_API_KEY in the environment. Gemini 2.0 Flash has a generous free tier; "
+    "typical development and demo usage costs nothing."
 )
 if st.button("Generate AI Summary"):
-    with st.spinner("Asking Claude to summarise the risks..."):
+    with st.spinner("Asking Gemini to summarise the risks..."):
         try:
             summary_md = summarize_risks(report, config)
             st.session_state["risk_summary_md"] = summary_md

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=2.0.0
 matplotlib>=3.7.0
 seaborn>=0.12.0
 scikit-learn>=1.3.0
-anthropic>=0.40
+google-genai>=1.0

--- a/src/auris/audit_risk.py
+++ b/src/auris/audit_risk.py
@@ -327,10 +327,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ml-random-state", type=int, default=DEFAULT_CONFIG.ml_random_state,
                         help="Random seed for deterministic ML runs (default 42)")
     parser.add_argument("--summarize", action="store_true",
-                        help="Generate a Claude-written executive summary of the report "
-                             "(requires ANTHROPIC_API_KEY); writes risk_summary.md")
+                        help="Generate an AI-written executive summary of the report "
+                             "(requires GOOGLE_API_KEY); writes risk_summary.md")
     parser.add_argument("--summary-model", type=str, default=DEFAULT_CONFIG.summary_model,
-                        help="Claude model id for the AI summary (default claude-haiku-4-5)")
+                        help="Gemini model id for the AI summary (default gemini-2.0-flash-001)")
     parser.add_argument("--summary-max-tokens", type=int, default=DEFAULT_CONFIG.summary_max_tokens,
                         help="Max tokens for the AI summary output (default 1024)")
     parser.add_argument("-v", "--verbose", action="count", default=0,

--- a/src/auris/config.py
+++ b/src/auris/config.py
@@ -25,11 +25,11 @@ class RiskConfig:
         ml_n_estimators: Number of trees in the Isolation Forest ensemble.
             Default 200.
         ml_random_state: Random seed for deterministic ML runs. Default 42.
-        summary_model: Claude model id used by the AI summary layer.
-            Default "claude-haiku-4-5" (cheapest tier, sufficient for short
+        summary_model: Gemini model id used by the AI summary layer.
+            Default "gemini-2.0-flash-001" (free tier, sufficient for short
             executive summaries).
         summary_max_tokens: Hard cap on summary output length in tokens.
-            Default 1024 (keeps cost predictable; one CFO-readable summary).
+            Default 1024 (keeps output bounded; one CFO-readable summary).
     """
 
     anomaly_quantile: float = 0.9
@@ -39,7 +39,7 @@ class RiskConfig:
     ml_contamination: float = 0.05
     ml_n_estimators: int = 200
     ml_random_state: int = 42
-    summary_model: str = "claude-haiku-4-5"
+    summary_model: str = "gemini-2.0-flash-001"
     summary_max_tokens: int = 1024
 
 

--- a/src/auris/summarize.py
+++ b/src/auris/summarize.py
@@ -1,13 +1,15 @@
-"""Claude-powered natural-language summaries of an AuRIS risk report.
+"""Gemini-powered natural-language summaries of an AuRIS risk report.
 
-Reads `ANTHROPIC_API_KEY` from the environment, sends a compact projection
+Reads `GOOGLE_API_KEY` from the environment, sends a compact projection
 of the risk report (top-N highest-amount rows per `risk_type`) to the
-Anthropic API, and returns a CFO-readable Markdown summary.
+Google Gemini API, and returns a CFO-readable Markdown summary.
 
 Designed for cost: the prompt is bounded by `_TOP_N_PER_TYPE * num_risk_types`
 rows regardless of input size, and the output is capped via
 `RiskConfig.summary_max_tokens`. Empty reports short-circuit without
-calling the API at all.
+calling the API at all. Gemini 2.0 Flash has a generous free tier
+(1,500 requests/day, no credit card required), so typical development
+and demo usage costs nothing.
 """
 import logging
 import os
@@ -63,11 +65,11 @@ def summarize_risks(
     config: RiskConfig = DEFAULT_CONFIG,
     client: Optional[object] = None,
 ) -> str:
-    """Generate a Markdown executive summary of the risk report via Claude.
+    """Generate a Markdown executive summary of the risk report via Gemini.
 
     Returns a canned no-risk message and does not hit the API when the
-    report is empty. Raises RuntimeError if `ANTHROPIC_API_KEY` is unset.
-    `client` is an optional pre-built Anthropic client, useful for tests.
+    report is empty. Raises RuntimeError if `GOOGLE_API_KEY` is unset.
+    `client` is an optional pre-built genai.Client, useful for tests.
     """
     if report is None or report.empty:
         logger.info("risk report is empty; skipping API call.")
@@ -76,17 +78,19 @@ def summarize_risks(
     if "risk_type" not in report.columns:
         raise ValueError("report must include a 'risk_type' column.")
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
     if not api_key:
         raise RuntimeError(
-            "ANTHROPIC_API_KEY environment variable is required for the "
-            "summary feature. Get a key from platform.claude.com and set it "
-            "in your environment (e.g. via a .env file)."
+            "GOOGLE_API_KEY environment variable is required for the summary "
+            "feature. Get a free key from https://aistudio.google.com/apikey "
+            "and set it in your environment (e.g. via a .env file)."
         )
 
     if client is None:
-        import anthropic
-        client = anthropic.Anthropic()
+        from google import genai
+        client = genai.Client()
+
+    from google.genai import types
 
     user_prompt = _build_prompt(report)
     logger.info(
@@ -94,18 +98,17 @@ def summarize_risks(
         config.summary_model, config.summary_max_tokens, len(user_prompt),
     )
 
-    response = client.messages.create(
+    response = client.models.generate_content(
         model=config.summary_model,
-        max_tokens=config.summary_max_tokens,
-        system=_SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_prompt}],
+        contents=user_prompt,
+        config=types.GenerateContentConfig(
+            system_instruction=_SYSTEM_PROMPT,
+            max_output_tokens=config.summary_max_tokens,
+        ),
     )
 
-    for block in response.content:
-        if getattr(block, "type", None) == "text":
-            text = block.text.strip()
-            if text:
-                return text
-
-    logger.warning("AI summary response contained no text block; returning empty message.")
-    return _EMPTY_REPORT_MESSAGE
+    text = getattr(response, "text", None)
+    if not text or not text.strip():
+        logger.warning("AI summary response was empty; returning canned message.")
+        return _EMPTY_REPORT_MESSAGE
+    return text.strip()

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,7 +1,7 @@
-"""Tests for the Claude-powered AI summary layer.
+"""Tests for the Gemini-powered AI summary layer.
 
-All tests use a mocked Anthropic client; no real API calls are made,
-so CI does not require ANTHROPIC_API_KEY.
+All tests use a mocked Gemini client; no real API calls are made,
+so CI does not require GOOGLE_API_KEY.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -13,16 +13,15 @@ from auris.config import RiskConfig
 from auris.summarize import _EMPTY_REPORT_MESSAGE, summarize_risks
 
 
-def _fake_anthropic_response(text: str) -> SimpleNamespace:
-    """Mimic the shape of an anthropic.types.Message: content is a list of blocks."""
-    text_block = SimpleNamespace(type="text", text=text)
-    return SimpleNamespace(content=[text_block])
+def _fake_gemini_response(text: str) -> SimpleNamespace:
+    """Mimic the shape of a google.genai response: object with a `.text` attribute."""
+    return SimpleNamespace(text=text)
 
 
 def _mock_client(reply_text: str = "# AuRIS Risk Summary\n\nSummary body.") -> MagicMock:
-    """Build a MagicMock Anthropic client whose messages.create returns reply_text."""
+    """Build a MagicMock genai.Client whose models.generate_content returns reply_text."""
     client = MagicMock()
-    client.messages.create.return_value = _fake_anthropic_response(reply_text)
+    client.models.generate_content.return_value = _fake_gemini_response(reply_text)
     return client
 
 
@@ -37,21 +36,21 @@ def small_report() -> pd.DataFrame:
     ])
 
 
-def test_summarize_risks_happy_path_calls_anthropic_with_expected_args(
+def test_summarize_risks_happy_path_calls_gemini_with_expected_args(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
-    """Mock the Anthropic client and verify model, max_tokens, and prompt contents."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    """Mock the Gemini client and verify model, max_tokens, system, and prompt contents."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
     client = _mock_client("# AuRIS Risk Summary\n\n- Found duplicates and one anomaly.")
 
     result = summarize_risks(small_report, RiskConfig(), client=client)
 
-    assert client.messages.create.call_count == 1
-    kwargs = client.messages.create.call_args.kwargs
-    assert kwargs["model"] == "claude-haiku-4-5"
-    assert kwargs["max_tokens"] == 1024
-    assert kwargs["system"].startswith("You are a senior audit analyst")
-    user_prompt = kwargs["messages"][0]["content"]
+    assert client.models.generate_content.call_count == 1
+    kwargs = client.models.generate_content.call_args.kwargs
+    assert kwargs["model"] == "gemini-2.0-flash-001"
+    assert kwargs["config"].system_instruction.startswith("You are a senior audit analyst")
+    assert kwargs["config"].max_output_tokens == 1024
+    user_prompt = kwargs["contents"]
     assert "Duplicate" in user_prompt
     assert "Anomaly" in user_prompt
     assert "Missing Data" in user_prompt
@@ -63,22 +62,23 @@ def test_summarize_risks_empty_report_returns_canned_message_without_api_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An empty report short-circuits: returns the canned message, never hits the API."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
     client = _mock_client()
 
     result = summarize_risks(pd.DataFrame(), RiskConfig(), client=client)
 
     assert result == _EMPTY_REPORT_MESSAGE
-    assert client.messages.create.call_count == 0
+    assert client.models.generate_content.call_count == 0
 
 
 def test_summarize_risks_missing_api_key_raises_clear_error(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
-    """When ANTHROPIC_API_KEY is unset, raise RuntimeError with a clear message."""
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    """When neither GOOGLE_API_KEY nor GEMINI_API_KEY is set, raise RuntimeError."""
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 
-    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+    with pytest.raises(RuntimeError, match="GOOGLE_API_KEY"):
         summarize_risks(small_report, RiskConfig())
 
 
@@ -86,22 +86,22 @@ def test_summarize_risks_respects_custom_model_and_max_tokens(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
     """RiskConfig overrides for summary_model and summary_max_tokens are honoured."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
     client = _mock_client()
-    config = RiskConfig(summary_model="claude-sonnet-4-6", summary_max_tokens=2048)
+    config = RiskConfig(summary_model="gemini-2.5-pro", summary_max_tokens=2048)
 
     summarize_risks(small_report, config, client=client)
 
-    kwargs = client.messages.create.call_args.kwargs
-    assert kwargs["model"] == "claude-sonnet-4-6"
-    assert kwargs["max_tokens"] == 2048
+    kwargs = client.models.generate_content.call_args.kwargs
+    assert kwargs["model"] == "gemini-2.5-pro"
+    assert kwargs["config"].max_output_tokens == 2048
 
 
 def test_summarize_risks_returns_non_empty_markdown_string(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
     """The function returns a non-empty string that looks like Markdown."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
     client = _mock_client("# Heading\n\n- bullet 1\n- bullet 2\n")
 
     result = summarize_risks(small_report, RiskConfig(), client=client)


### PR DESCRIPTION
## Summary
- Anthropic API billing was rejecting this account's card (Claude.ai Pro accepts the same card, the API billing pipeline did not). Rather than block on payments, the summary layer moves to Google Gemini 2.0 Flash, which has a generous free tier (1,500 requests/day, no credit card required) and comparable quality for short executive summaries.
- Public surface is unchanged: \`summarize_risks(report, config) -> str\` keeps the same signature, the \`--summarize\` CLI flag and the Streamlit "Generate AI Summary" button work as before, and the 5 mocked tests keep the same names and scenarios. Only the mock target swaps to the \`google-genai\` client.
- \`requirements.txt\` swaps \`anthropic>=0.40\` for \`google-genai>=1.0\`. \`RiskConfig.summary_model\` default becomes \`"gemini-2.0-flash-001"\`. The error message for a missing key now points at \`aistudio.google.com/apikey\` and reads \`GOOGLE_API_KEY\` (with \`GEMINI_API_KEY\` as a fallback).
- README "AI-Augmented Summaries" section rewritten end-to-end for the Gemini flow (setup, env var, cost). Roadmap row reflects the swap.

## Test plan
- [ ] CI: \`pytest\` matrix green on Python 3.10 / 3.11 / 3.12 with all 23 tests passing.
- [ ] Local with \`GOOGLE_API_KEY\` set: \`python -m auris -i data/transactions.csv -o output --summarize -v\` writes a sensible \`output/risk_summary.md\`.
- [ ] Local Streamlit: \`streamlit run app.py\`, click "Generate AI Summary", confirm Markdown renders and downloads cleanly.
- [ ] Empty-report short circuit: a synthetic clean CSV runs through \`--summarize\` and writes the canned no-risks summary without spending any quota.