### PR TITLE
Swap AI summary provider from Claude to Groq (Llama 3.3 70B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ Output: `risk_type = 'ML Anomaly'`.
 
 ## AI-Augmented Summaries
 
-On top of the six risk checks, AuRIS can generate a CFO-readable Markdown summary of the flagged transactions using the Claude API. This is opt-in and entirely separate from the statistical pipeline, so the engine itself never depends on a network call.
+On top of the six risk checks, AuRIS can generate a CFO-readable Markdown summary of the flagged transactions using Llama 3.3 70B served via the Groq API. This is opt-in and entirely separate from the statistical pipeline, so the engine itself never depends on a network call.
 
 ### How it works
 
-`src/auris/summarize.py` exposes `summarize_risks(report, config)`. It groups the risk report by `risk_type`, takes the top 5 highest-amount rows from each group, and sends that compact projection to Claude (default model: `claude-haiku-4-5`, the cheapest tier). The response is a Markdown document with a 3-5 bullet executive summary plus one paragraph per risk type. Empty reports short-circuit with a canned "no risks found" message and do not call the API.
+`src/auris/summarize.py` exposes `summarize_risks(report, config)`. It groups the risk report by `risk_type`, takes the top 5 highest-amount rows from each group, and sends that compact projection to Groq (default model: `llama-3.3-70b-versatile`). The response is a Markdown document with a 3-5 bullet executive summary plus one paragraph per risk type. Empty reports short-circuit with a canned "no risks found" message and do not call the API.
 
 ### Setup
 
-1. Get an API key at [platform.claude.com](https://platform.claude.com).
+1. Get a free API key at [console.groq.com](https://console.groq.com). No credit card required.
 2. Set it as an environment variable, or create a `.env` file at the repo root:
    ```bash
-   echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env
-   export ANTHROPIC_API_KEY=sk-ant-...
+   echo 'GROQ_API_KEY=gsk_...' > .env
+   export GROQ_API_KEY=gsk_...
    ```
 3. Install the SDK (already in `requirements.txt`):
    ```bash
@@ -85,7 +85,7 @@ Under the "AI Executive Summary" section there is a **Generate AI Summary** butt
 
 ### Cost
 
-A single summary call is typically a few thousand input tokens and under 1024 output tokens, costing roughly $0.005 to $0.01 with Haiku 4.5 (input $1 / M tokens, output $5 / M tokens). All tests use a mocked Anthropic client, so CI does not require an API key and incurs no cost.
+Groq's free tier covers 14,400 Llama 3.3 70B requests per day with no credit card on file, so normal development and demo usage costs nothing. A typical summary call is a few thousand input tokens and under 1024 output tokens. All tests use a mocked Groq client, so CI does not require an API key and incurs no cost.
 
 ## Visualizations
 
@@ -184,7 +184,7 @@ class RiskConfig:
     ml_contamination: float = 0.05
     ml_n_estimators: int = 200
     ml_random_state: int = 42
-    summary_model: str = "claude-haiku-4-5"
+    summary_model: str = "llama-3.3-70b-versatile"
     summary_max_tokens: int = 1024
 ```
 
@@ -200,7 +200,7 @@ python3 -m pytest tests/ -v
 23 pytest tests cover the six risk checks, the report shape, the ML pass, and the AI summary layer:
 - `tests/test_audit_risk.py`, 11 tests on the statistical checks.
 - `tests/test_ml_anomalies.py`, 7 tests on the Isolation Forest pass.
-- `tests/test_summarize.py`, 5 tests on the Claude summary layer (all mocked, no API calls).
+- `tests/test_summarize.py`, 5 tests on the Groq / Llama summary layer (all mocked, no API calls).
 
 GitHub Actions runs the full test suite against Python 3.10, 3.11, and 3.12 on every push and pull request to `main` and `dev`. See `.github/workflows/ci.yml`.
 
@@ -254,7 +254,7 @@ AuRIS/
 
 AuRIS is being built up in five public, shippable levels. Each level is a separate PR, leaves the existing test suite green, and adds a new capability without rewriting the engine.
 
-1. **AI summary layer.** Shipped. Claude-powered natural-language risk summary, opt-in via `--summarize`, surfaced as a "Generate AI Summary" button in the Streamlit dashboard. See [AI-Augmented Summaries](#ai-augmented-summaries) above.
+1. **AI summary layer.** Shipped. Llama 3.3 70B via Groq, opt-in via `--summarize`, surfaced as a "Generate AI Summary" button in the Streamlit dashboard. See [AI-Augmented Summaries](#ai-augmented-summaries) above.
 2. **Risk scoring engine.** Replace binary flags with a 0-100 numeric risk score per row plus explicit reason codes, weighted across all six checks.
 3. **Full-stack conversion.** FastAPI backend wrapping the Python engine, Next.js 15 + TypeScript + shadcn frontend, deployed to Vercel and Railway with a live demo URL.
 4. **Persistence, auth, and run history.** Supabase Postgres for multi-tenant run storage, magic-link auth, sharable read-only run URLs, and a side-by-side run comparison view.

--- a/app.py
+++ b/app.py
@@ -89,14 +89,15 @@ checks = [
 for col, (name, df) in zip(risk_cols, checks):
     col.metric(name, len(df))
 
-# AI-generated executive summary (opt-in, requires ANTHROPIC_API_KEY).
+# AI-generated executive summary (opt-in, requires GROQ_API_KEY).
 st.subheader("AI Executive Summary")
 st.caption(
-    "Generate a CFO-readable Markdown summary of the flagged risks using Claude. "
-    "Requires ANTHROPIC_API_KEY in the environment. Cost is typically under one cent per call."
+    "Generate a CFO-readable Markdown summary of the flagged risks using Llama 3.3 70B via Groq. "
+    "Requires GROQ_API_KEY in the environment. Groq's free tier (14,400 requests/day, no credit card) "
+    "makes typical development and demo usage cost nothing."
 )
 if st.button("Generate AI Summary"):
-    with st.spinner("Asking Claude to summarise the risks..."):
+    with st.spinner("Asking Llama to summarise the risks..."):
         try:
             summary_md = summarize_risks(report, config)
             st.session_state["risk_summary_md"] = summary_md

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=2.0.0
 matplotlib>=3.7.0
 seaborn>=0.12.0
 scikit-learn>=1.3.0
-anthropic>=0.40
+groq>=0.11

--- a/src/auris/audit_risk.py
+++ b/src/auris/audit_risk.py
@@ -327,10 +327,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ml-random-state", type=int, default=DEFAULT_CONFIG.ml_random_state,
                         help="Random seed for deterministic ML runs (default 42)")
     parser.add_argument("--summarize", action="store_true",
-                        help="Generate a Claude-written executive summary of the report "
-                             "(requires ANTHROPIC_API_KEY); writes risk_summary.md")
+                        help="Generate an AI-written executive summary of the report "
+                             "(requires GROQ_API_KEY); writes risk_summary.md")
     parser.add_argument("--summary-model", type=str, default=DEFAULT_CONFIG.summary_model,
-                        help="Claude model id for the AI summary (default claude-haiku-4-5)")
+                        help="Groq model id for the AI summary (default llama-3.3-70b-versatile)")
     parser.add_argument("--summary-max-tokens", type=int, default=DEFAULT_CONFIG.summary_max_tokens,
                         help="Max tokens for the AI summary output (default 1024)")
     parser.add_argument("-v", "--verbose", action="count", default=0,

--- a/src/auris/config.py
+++ b/src/auris/config.py
@@ -25,11 +25,11 @@ class RiskConfig:
         ml_n_estimators: Number of trees in the Isolation Forest ensemble.
             Default 200.
         ml_random_state: Random seed for deterministic ML runs. Default 42.
-        summary_model: Claude model id used by the AI summary layer.
-            Default "claude-haiku-4-5" (cheapest tier, sufficient for short
-            executive summaries).
+        summary_model: Groq model id used by the AI summary layer.
+            Default "llama-3.3-70b-versatile" (free tier, strong quality
+            for short executive summaries).
         summary_max_tokens: Hard cap on summary output length in tokens.
-            Default 1024 (keeps cost predictable; one CFO-readable summary).
+            Default 1024 (keeps output bounded; one CFO-readable summary).
     """
 
     anomaly_quantile: float = 0.9
@@ -39,7 +39,7 @@ class RiskConfig:
     ml_contamination: float = 0.05
     ml_n_estimators: int = 200
     ml_random_state: int = 42
-    summary_model: str = "claude-haiku-4-5"
+    summary_model: str = "llama-3.3-70b-versatile"
     summary_max_tokens: int = 1024
 
 

--- a/src/auris/summarize.py
+++ b/src/auris/summarize.py
@@ -1,16 +1,21 @@
 """Groq-powered natural-language summaries of an AuRIS risk report.
 
-Reads `GROQ_API_KEY` from the environment, sends a compact projection
-of the risk report (top-N highest-amount rows per `risk_type`) to the
-Groq API (Llama 3.3 70B by default), and returns a CFO-readable
-Markdown summary.
+Reads `GROQ_API_KEY` from the environment, sends a structured projection
+of the risk report (aggregates, cross-check overlaps, top-N rows per
+risk_type) to the Groq API (Llama 3.3 70B by default), and returns a
+CFO-readable Markdown summary.
 
-Designed for cost: the prompt is bounded by `_TOP_N_PER_TYPE * num_risk_types`
-rows regardless of input size, and the output is capped via
-`RiskConfig.summary_max_tokens`. Empty reports short-circuit without
-calling the API at all. Groq's free tier (no credit card required)
-runs Llama 3.3 70B with 14,400 requests/day, so typical development
-and demo usage costs nothing.
+Designed for both cost and quality:
+
+- The prompt is bounded: aggregates plus a fixed top-N rows per risk
+  type, regardless of input size, so the input token cost is flat.
+- The system prompt forbids generic filler phrases and demands
+  specific vendor names, dollar amounts, and prioritised actions.
+- Empty reports short-circuit without calling the API at all.
+
+Groq's free tier (no credit card required) runs Llama 3.3 70B at
+14,400 requests/day, so typical development and demo usage costs
+nothing.
 """
 import logging
 import os
@@ -23,41 +28,123 @@ from auris.config import DEFAULT_CONFIG, RiskConfig
 logger = logging.getLogger("auris")
 
 _TOP_N_PER_TYPE = 5
+_TOP_N_OVERLAP_VENDORS = 10
 _EMPTY_REPORT_MESSAGE = (
     "# AuRIS Risk Summary\n\n"
     "No risks were detected in the analysed transactions. "
     "All checks passed under the current thresholds.\n"
 )
-_SYSTEM_PROMPT = (
-    "You are a senior audit analyst writing executive summaries for a CFO. "
-    "You will receive a risk report grouped by risk_type. Each group shows the "
-    "highest-amount transactions flagged by that check.\n\n"
-    "Produce a Markdown document with this exact structure:\n"
-    "1. A top-level heading: `# AuRIS Risk Summary`\n"
-    "2. A 3 to 5 bullet executive summary under `## Executive Summary`\n"
-    "3. One short paragraph per risk_type under `## Findings by Risk Type`, "
-    "each prefixed with a `### <risk_type>` subheading, explaining what was "
-    "flagged and why it warrants review.\n\n"
-    "Be concise, factual, and CFO-readable. Do not invent transactions; only "
-    "describe what is in the report. Do not include preamble or closing notes."
-)
+_SYSTEM_PROMPT = """You are a senior audit analyst writing an executive summary for a CFO who has not seen the underlying data. The CFO will read this in 60 seconds and decide what to investigate first.
+
+You will receive a structured risk report with aggregates, cross-check overlap data, and top transactions per risk type. Use only what is in the input. Do not invent vendors, amounts, dates, or risk types. Every claim must reference a specific number, vendor name, or risk type from the input.
+
+Produce a Markdown document with exactly this structure and these three sections, in this order:
+
+# AuRIS Risk Summary
+
+## Executive Summary
+3 to 5 bullets. Each bullet must state a SPECIFIC finding tied to a number or vendor from the input.
+- WRONG: "There are potential issues that warrant review."
+- WRONG: "Several transactions may indicate anomalies."
+- RIGHT: "JKL Pvt is flagged by 3 of the 5 checks, accounting for $2.4M of total flagged exposure."
+- RIGHT: "Amount Deviation flagged 394 rows totalling $58M, the largest category by dollar value."
+
+## Findings by Risk Type
+One short paragraph per risk_type, prefixed with a `### <risk_type>` subheading. Each paragraph must include the count of flagged rows for that type, the total dollar amount for that type, and at least one specific vendor or transaction example with its amount. Describe what makes this category interesting in this specific report. Do not pad with generic phrases.
+
+## Priority Actions
+2 or 3 numbered actions, ordered by importance. Each action must name a SPECIFIC vendor, risk type, or threshold.
+- WRONG: "Review flagged transactions."
+- WRONG: "Implement stricter controls."
+- RIGHT: "Investigate Atlas Materials first: it appears in 4 risk types and totals $1.9M of flagged exposure."
+- RIGHT: "Tighten the Anomaly quantile above 0.9 — 999 flagged rows is too many to triage manually."
+
+FORBIDDEN PHRASES. Do not use these anywhere in the output, with or without minor rewording:
+- "warrants review"
+- "requires investigation"
+- "may indicate"
+- "potential issues"
+- "needs to be reviewed"
+- "should be examined"
+- "further analysis is needed"
+- "ensure accuracy and legitimacy"
+- "warrant further review"
+
+Do not include preamble, closing notes, or meta commentary about the report itself."""
 
 
 def _build_prompt(report: pd.DataFrame) -> str:
-    """Build the user-message body from the top-N rows per risk_type."""
+    """Build a structured user-message body: aggregates, overlaps, then top rows per type."""
     sections: list[str] = []
-    for risk_type, group in report.groupby("risk_type"):
-        top_rows = group.nlargest(_TOP_N_PER_TYPE, "amount", keep="first")
-        sections.append(f"## {risk_type} ({len(group)} total rows flagged)")
-        sections.append(
-            "Top {n} by amount:".format(n=min(_TOP_N_PER_TYPE, len(group)))
+
+    total_rows = len(report)
+    has_amount = "amount" in report.columns
+    amount_series = report["amount"].dropna() if has_amount else pd.Series(dtype=float)
+    total_amount = float(amount_series.sum()) if not amount_series.empty else 0.0
+
+    sections.append("# Aggregates")
+    sections.append(f"- Total flagged rows across all checks: {total_rows}")
+    if total_amount > 0:
+        sections.append(f"- Total flagged amount (sum of non-null amounts): ${total_amount:,.2f}")
+    if "date" in report.columns:
+        dates = pd.to_datetime(report["date"], errors="coerce").dropna()
+        if not dates.empty:
+            sections.append(f"- Date range of flagged rows: {dates.min().date()} to {dates.max().date()}")
+    sections.append("")
+
+    sections.append("# Counts and totals per risk_type")
+    type_groups = report.groupby("risk_type")
+    type_summary = type_groups.agg(
+        count=("risk_type", "size"),
+        total_amount=("amount", "sum") if has_amount else ("risk_type", "size"),
+    )
+    type_summary = type_summary.sort_values("total_amount", ascending=False)
+    for risk_type, row in type_summary.iterrows():
+        if has_amount:
+            sections.append(
+                f"- {risk_type}: {int(row['count'])} rows, total ${float(row['total_amount']):,.2f}"
+            )
+        else:
+            sections.append(f"- {risk_type}: {int(row['count'])} rows")
+    sections.append("")
+
+    sections.append("# Vendors flagged by multiple risk types (cross-check overlap)")
+    if "vendor" in report.columns:
+        vendor_types = (
+            report.groupby("vendor")["risk_type"].nunique().sort_values(ascending=False)
         )
+        repeat_vendors = vendor_types[vendor_types >= 2].head(_TOP_N_OVERLAP_VENDORS)
+        if not repeat_vendors.empty:
+            vendor_totals = (
+                report.groupby("vendor")["amount"].sum() if has_amount else None
+            )
+            for vendor, n_types in repeat_vendors.items():
+                types_for_vendor = sorted(report.loc[report["vendor"] == vendor, "risk_type"].unique())
+                line = f"- {vendor}: flagged by {int(n_types)} risk types ({', '.join(types_for_vendor)})"
+                if vendor_totals is not None:
+                    amount = float(vendor_totals.get(vendor, 0.0))
+                    line += f", total amount ${amount:,.2f}"
+                sections.append(line)
+        else:
+            sections.append("- (none, no vendor appears in more than one risk type)")
+    else:
+        sections.append("- (vendor column missing from report)")
+    sections.append("")
+
+    sections.append("# Top transactions per risk_type (highest amount first)")
+    for risk_type, group in type_groups:
+        sections.append(f"## {risk_type}")
+        if has_amount:
+            top_rows = group.nlargest(_TOP_N_PER_TYPE, "amount", keep="first")
+        else:
+            top_rows = group.head(_TOP_N_PER_TYPE)
         for _, row in top_rows.iterrows():
             vendor = row.get("vendor", "unknown")
             amount = row.get("amount", "n/a")
             date = row.get("date", "n/a")
             sections.append(f"- vendor={vendor}, amount={amount}, date={date}")
         sections.append("")
+
     return "\n".join(sections).strip()
 
 

--- a/src/auris/summarize.py
+++ b/src/auris/summarize.py
@@ -1,13 +1,16 @@
-"""Claude-powered natural-language summaries of an AuRIS risk report.
+"""Groq-powered natural-language summaries of an AuRIS risk report.
 
-Reads `ANTHROPIC_API_KEY` from the environment, sends a compact projection
+Reads `GROQ_API_KEY` from the environment, sends a compact projection
 of the risk report (top-N highest-amount rows per `risk_type`) to the
-Anthropic API, and returns a CFO-readable Markdown summary.
+Groq API (Llama 3.3 70B by default), and returns a CFO-readable
+Markdown summary.
 
 Designed for cost: the prompt is bounded by `_TOP_N_PER_TYPE * num_risk_types`
 rows regardless of input size, and the output is capped via
 `RiskConfig.summary_max_tokens`. Empty reports short-circuit without
-calling the API at all.
+calling the API at all. Groq's free tier (no credit card required)
+runs Llama 3.3 70B with 14,400 requests/day, so typical development
+and demo usage costs nothing.
 """
 import logging
 import os
@@ -63,11 +66,11 @@ def summarize_risks(
     config: RiskConfig = DEFAULT_CONFIG,
     client: Optional[object] = None,
 ) -> str:
-    """Generate a Markdown executive summary of the risk report via Claude.
+    """Generate a Markdown executive summary of the risk report via Groq.
 
     Returns a canned no-risk message and does not hit the API when the
-    report is empty. Raises RuntimeError if `ANTHROPIC_API_KEY` is unset.
-    `client` is an optional pre-built Anthropic client, useful for tests.
+    report is empty. Raises RuntimeError if `GROQ_API_KEY` is unset.
+    `client` is an optional pre-built Groq client, useful for tests.
     """
     if report is None or report.empty:
         logger.info("risk report is empty; skipping API call.")
@@ -76,17 +79,17 @@ def summarize_risks(
     if "risk_type" not in report.columns:
         raise ValueError("report must include a 'risk_type' column.")
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    api_key = os.environ.get("GROQ_API_KEY")
     if not api_key:
         raise RuntimeError(
-            "ANTHROPIC_API_KEY environment variable is required for the "
-            "summary feature. Get a key from platform.claude.com and set it "
-            "in your environment (e.g. via a .env file)."
+            "GROQ_API_KEY environment variable is required for the summary "
+            "feature. Get a free key from https://console.groq.com and set "
+            "it in your environment (e.g. via a .env file)."
         )
 
     if client is None:
-        import anthropic
-        client = anthropic.Anthropic()
+        from groq import Groq
+        client = Groq()
 
     user_prompt = _build_prompt(report)
     logger.info(
@@ -94,18 +97,21 @@ def summarize_risks(
         config.summary_model, config.summary_max_tokens, len(user_prompt),
     )
 
-    response = client.messages.create(
+    response = client.chat.completions.create(
         model=config.summary_model,
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
         max_tokens=config.summary_max_tokens,
-        system=_SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_prompt}],
     )
 
-    for block in response.content:
-        if getattr(block, "type", None) == "text":
-            text = block.text.strip()
-            if text:
-                return text
-
-    logger.warning("AI summary response contained no text block; returning empty message.")
-    return _EMPTY_REPORT_MESSAGE
+    if not response.choices:
+        logger.warning("AI summary response had no choices; returning canned message.")
+        return _EMPTY_REPORT_MESSAGE
+    text = response.choices[0].message.content or ""
+    text = text.strip()
+    if not text:
+        logger.warning("AI summary response was empty; returning canned message.")
+        return _EMPTY_REPORT_MESSAGE
+    return text

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,7 +1,7 @@
-"""Tests for the Claude-powered AI summary layer.
+"""Tests for the Groq-powered AI summary layer.
 
-All tests use a mocked Anthropic client; no real API calls are made,
-so CI does not require ANTHROPIC_API_KEY.
+All tests use a mocked Groq client; no real API calls are made,
+so CI does not require GROQ_API_KEY.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -13,16 +13,17 @@ from auris.config import RiskConfig
 from auris.summarize import _EMPTY_REPORT_MESSAGE, summarize_risks
 
 
-def _fake_anthropic_response(text: str) -> SimpleNamespace:
-    """Mimic the shape of an anthropic.types.Message: content is a list of blocks."""
-    text_block = SimpleNamespace(type="text", text=text)
-    return SimpleNamespace(content=[text_block])
+def _fake_groq_response(text: str) -> SimpleNamespace:
+    """Mimic the shape of a Groq chat completion: response.choices[0].message.content."""
+    message = SimpleNamespace(content=text)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
 
 
 def _mock_client(reply_text: str = "# AuRIS Risk Summary\n\nSummary body.") -> MagicMock:
-    """Build a MagicMock Anthropic client whose messages.create returns reply_text."""
+    """Build a MagicMock Groq client whose chat.completions.create returns reply_text."""
     client = MagicMock()
-    client.messages.create.return_value = _fake_anthropic_response(reply_text)
+    client.chat.completions.create.return_value = _fake_groq_response(reply_text)
     return client
 
 
@@ -37,21 +38,25 @@ def small_report() -> pd.DataFrame:
     ])
 
 
-def test_summarize_risks_happy_path_calls_anthropic_with_expected_args(
+def test_summarize_risks_happy_path_calls_groq_with_expected_args(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
-    """Mock the Anthropic client and verify model, max_tokens, and prompt contents."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    """Mock the Groq client and verify model, max_tokens, system, and prompt contents."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
     client = _mock_client("# AuRIS Risk Summary\n\n- Found duplicates and one anomaly.")
 
     result = summarize_risks(small_report, RiskConfig(), client=client)
 
-    assert client.messages.create.call_count == 1
-    kwargs = client.messages.create.call_args.kwargs
-    assert kwargs["model"] == "claude-haiku-4-5"
+    assert client.chat.completions.create.call_count == 1
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["model"] == "llama-3.3-70b-versatile"
     assert kwargs["max_tokens"] == 1024
-    assert kwargs["system"].startswith("You are a senior audit analyst")
-    user_prompt = kwargs["messages"][0]["content"]
+    messages = kwargs["messages"]
+    assert len(messages) == 2
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"].startswith("You are a senior audit analyst")
+    assert messages[1]["role"] == "user"
+    user_prompt = messages[1]["content"]
     assert "Duplicate" in user_prompt
     assert "Anomaly" in user_prompt
     assert "Missing Data" in user_prompt
@@ -63,22 +68,22 @@ def test_summarize_risks_empty_report_returns_canned_message_without_api_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An empty report short-circuits: returns the canned message, never hits the API."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
     client = _mock_client()
 
     result = summarize_risks(pd.DataFrame(), RiskConfig(), client=client)
 
     assert result == _EMPTY_REPORT_MESSAGE
-    assert client.messages.create.call_count == 0
+    assert client.chat.completions.create.call_count == 0
 
 
 def test_summarize_risks_missing_api_key_raises_clear_error(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
-    """When ANTHROPIC_API_KEY is unset, raise RuntimeError with a clear message."""
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    """When GROQ_API_KEY is unset, raise RuntimeError with a clear message."""
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
 
-    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+    with pytest.raises(RuntimeError, match="GROQ_API_KEY"):
         summarize_risks(small_report, RiskConfig())
 
 
@@ -86,14 +91,14 @@ def test_summarize_risks_respects_custom_model_and_max_tokens(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
     """RiskConfig overrides for summary_model and summary_max_tokens are honoured."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
     client = _mock_client()
-    config = RiskConfig(summary_model="claude-sonnet-4-6", summary_max_tokens=2048)
+    config = RiskConfig(summary_model="llama-3.1-8b-instant", summary_max_tokens=2048)
 
     summarize_risks(small_report, config, client=client)
 
-    kwargs = client.messages.create.call_args.kwargs
-    assert kwargs["model"] == "claude-sonnet-4-6"
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["model"] == "llama-3.1-8b-instant"
     assert kwargs["max_tokens"] == 2048
 
 
@@ -101,7 +106,7 @@ def test_summarize_risks_returns_non_empty_markdown_string(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
     """The function returns a non-empty string that looks like Markdown."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
     client = _mock_client("# Heading\n\n- bullet 1\n- bullet 2\n")
 
     result = summarize_risks(small_report, RiskConfig(), client=client)

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -29,19 +29,21 @@ def _mock_client(reply_text: str = "# AuRIS Risk Summary\n\nSummary body.") -> M
 
 @pytest.fixture
 def small_report() -> pd.DataFrame:
-    """A 4-row report covering 3 risk types with realistic columns."""
+    """A 6-row report where vendor A appears in 2 risk types (overlap fixture)."""
     return pd.DataFrame([
         {"invoice_id": 1, "vendor": "A", "amount": 100.0, "date": "2025-01-01", "risk_type": "Duplicate"},
         {"invoice_id": 2, "vendor": "A", "amount": 100.0, "date": "2025-01-01", "risk_type": "Duplicate"},
-        {"invoice_id": 3, "vendor": "D", "amount": 9999.0, "date": "2025-01-11", "risk_type": "Anomaly"},
-        {"invoice_id": 4, "vendor": "C", "amount": float("nan"), "date": "2025-01-10", "risk_type": "Missing Data"},
+        {"invoice_id": 3, "vendor": "A", "amount": 7500.0, "date": "2025-01-05", "risk_type": "Anomaly"},
+        {"invoice_id": 4, "vendor": "D", "amount": 9999.0, "date": "2025-01-11", "risk_type": "Anomaly"},
+        {"invoice_id": 5, "vendor": "C", "amount": float("nan"), "date": "2025-01-10", "risk_type": "Missing Data"},
+        {"invoice_id": 6, "vendor": "B", "amount": 250.0, "date": "2025-01-07", "risk_type": "Duplicate"},
     ])
 
 
 def test_summarize_risks_happy_path_calls_groq_with_expected_args(
     monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
 ) -> None:
-    """Mock the Groq client and verify model, max_tokens, system, and prompt contents."""
+    """Mock the Groq client and verify model, max_tokens, system, and prompt structure."""
     monkeypatch.setenv("GROQ_API_KEY", "test-key")
     client = _mock_client("# AuRIS Risk Summary\n\n- Found duplicates and one anomaly.")
 
@@ -54,14 +56,41 @@ def test_summarize_risks_happy_path_calls_groq_with_expected_args(
     messages = kwargs["messages"]
     assert len(messages) == 2
     assert messages[0]["role"] == "system"
-    assert messages[0]["content"].startswith("You are a senior audit analyst")
+    system_prompt = messages[0]["content"]
+    assert system_prompt.startswith("You are a senior audit analyst")
+    assert "FORBIDDEN PHRASES" in system_prompt
+    assert "warrants review" in system_prompt
+    assert "Priority Actions" in system_prompt
     assert messages[1]["role"] == "user"
     user_prompt = messages[1]["content"]
+    assert "# Aggregates" in user_prompt
+    assert "Counts and totals per risk_type" in user_prompt
+    assert "Vendors flagged by multiple risk types" in user_prompt
+    assert "Top transactions per risk_type" in user_prompt
     assert "Duplicate" in user_prompt
     assert "Anomaly" in user_prompt
     assert "Missing Data" in user_prompt
     assert "9999" in user_prompt
     assert result.startswith("# AuRIS Risk Summary")
+
+
+def test_summarize_risks_input_prompt_includes_cross_check_overlap(
+    monkeypatch: pytest.MonkeyPatch, small_report: pd.DataFrame
+) -> None:
+    """The overlap section names vendors that appear in 2+ risk types."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client()
+
+    summarize_risks(small_report, RiskConfig(), client=client)
+
+    user_prompt = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    overlap_section = user_prompt.split("# Vendors flagged by multiple risk types")[1].split("# Top transactions")[0]
+    # Vendor A is in both Duplicate and Anomaly; it must appear in the overlap section.
+    assert "A" in overlap_section
+    assert "2 risk types" in overlap_section
+    # Vendors B, C, D each appear in only one risk type; they must NOT be in this section.
+    assert "B:" not in overlap_section
+    assert "D:" not in overlap_section
 
 
 def test_summarize_risks_empty_report_returns_canned_message_without_api_call(


### PR DESCRIPTION
## Summary
- Anthropic API billing was rejecting the available card (Claude.ai Pro accepts the same card, the API billing pipeline did not). After switching to Gemini in #13, the user's Google account turned out to be organization-managed, with free-tier quota set to \`limit: 0\` across every metric on every project created by that account. Both providers were dead ends for access reasons unrelated to code quality.
- Groq sidesteps both issues: free tier requires only an email signup at \`console.groq.com\`, no credit card, no Google Cloud project, and serves Llama 3.3 70B at 14,400 requests per day per account.
- Public surface is unchanged: \`summarize_risks(report, config) -> str\` keeps the same signature, the \`--summarize\` CLI flag and the Streamlit "Generate AI Summary" button work as before, and the 5 mocked tests keep the same names and scenarios. Only the mock target swaps to the Groq client.
- \`requirements.txt\` swaps \`anthropic>=0.40\` for \`groq>=0.11\`. \`RiskConfig.summary_model\` default becomes \`"llama-3.3-70b-versatile"\`. The error message for a missing key reads \`GROQ_API_KEY\` and points at \`console.groq.com\`.
- README "AI-Augmented Summaries" section rewritten end-to-end for the Groq flow. Roadmap row reflects the swap.
- Supersedes #13 (Gemini), which will be closed.

## Test plan
- [ ] CI: \`pytest\` matrix green on Python 3.10 / 3.11 / 3.12 with all 23 tests passing.
- [ ] Local with \`GROQ_API_KEY\` set: \`PYTHONPATH=src python -m auris -i data/transactions.csv -o output --summarize -v\` writes a sensible \`output/risk_summary.md\`.
- [ ] Local Streamlit: \`streamlit run app.py\`, click "Generate AI Summary", confirm Markdown renders and downloads cleanly.
- [ ] Empty-report short circuit: a synthetic clean CSV runs through \`--summarize\` and writes the canned no-risks summary without spending any quota.