### PR TITLE
Add pyproject.toml and switch to editable install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
+      - name: Install AuRIS in editable mode
+        run: pip install -e . --no-deps
+
       - name: Run test suite
         run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ source venv/bin/activate     # On Windows: venv\Scripts\activate
 pip install -r requirements.txt           # Engine only
 pip install -r requirements-dev.txt       # Engine + pytest
 pip install -r requirements-app.txt       # Engine + Streamlit dashboard
+pip install -e .                          # Install AuRIS itself in editable mode
 ```
+
+The final `pip install -e .` step (powered by `pyproject.toml`) makes `auris` importable from anywhere and registers the `auris` console script, so `python -m auris ...` and `streamlit run app.py` work without manual `PYTHONPATH=src` prefixes.
 
 ### Optional: generate a synthetic dataset
 A seeded 10K-row generator with injected duplicates and outliers is included:

--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 """AuRIS Streamlit dashboard for interactive audit risk analysis."""
-import sys
 from pathlib import Path
 
 import streamlit as st
@@ -8,7 +7,6 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 
 PROJECT_ROOT = Path(__file__).resolve().parent
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from auris.audit_risk import (
     check_amount_deviation,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "auris"
+version = "0.1.0"
+description = "Audit Risk Identification System: statistical, ML, and AI-augmented anomaly detection for transaction CSVs."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "Amrit Dhandharia" }]
+license = { text = "MIT" }
+dynamic = ["dependencies"]
+
+[project.scripts]
+auris = "auris.audit_risk:main"
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,13 @@
 """Shared pytest fixtures for the AuRIS test suite."""
-import sys
-from pathlib import Path
+import logging
 
 import pandas as pd
 import pytest
 
-# Make `src/` importable so tests don't depend on packaging or PYTHONPATH.
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
+# `auris` is installed via `pip install -e .` (see pyproject.toml); no
+# sys.path manipulation needed.
 
 # Quiet the auris logger during tests.
-import logging
 logging.getLogger("auris").addHandler(logging.NullHandler())
 logging.getLogger("auris").propagate = False
 


### PR DESCRIPTION
## Summary
- Before this PR, running the AuRIS CLI required either \`PYTHONPATH=src python -m auris ...\` or the \`sys.path.insert\` hack in \`app.py\` and \`tests/conftest.py\`. Tests passed, but \`python -m auris\` failed as documented in the README. This footgun surfaced during the Level 1 smoke test.
- Adds \`pyproject.toml\` with src layout and dynamic dependencies (read from \`requirements.txt\` so the dep list stays in one place). Registers a console script so \`auris\` works as a bare command after install.
- CI workflow adds \`pip install -e . --no-deps\` so the test environment exercises the same import path users hit in production.
- Removes the \`sys.path.insert\` hacks from \`tests/conftest.py\` and \`app.py\`. The README now documents \`pip install -e .\` as part of the install flow.

## Test plan
- [ ] CI: pytest matrix green on Python 3.10 / 3.11 / 3.12 with all 24 tests passing.
- [ ] After merge and a local \`pip install -e .\`, \`python -m auris --help\` works without any \`PYTHONPATH\` prefix.
- [ ] \`streamlit run app.py\` works from a clean shell after \`pip install -e .\` and \`pip install -r requirements-app.txt\`.