### PR TITLE
Auto-load .env via python-dotenv in CLI and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,16 @@ On top of the six risk checks, AuRIS can generate a CFO-readable Markdown summar
 ### Setup
 
 1. Get a free API key at [console.groq.com](https://console.groq.com). No credit card required.
-2. Set it as an environment variable, or create a `.env` file at the repo root:
+2. Create a `.env` file at the repo root:
    ```bash
    echo 'GROQ_API_KEY=gsk_...' > .env
-   export GROQ_API_KEY=gsk_...
    ```
 3. Install the SDK (already in `requirements.txt`):
    ```bash
    pip install -r requirements.txt
    ```
 
-The `.env` file and any `*.key` / `secrets.json` are gitignored. Never commit your API key.
+Both `python -m auris` and `streamlit run app.py` auto-load `.env` via [python-dotenv](https://github.com/theskumar/python-dotenv), so the key is picked up automatically on every run. The `.env` file and any `*.key` / `secrets.json` are gitignored. Never commit your API key.
 
 ### CLI usage
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,10 @@
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import streamlit as st
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib>=3.7.0
 seaborn>=0.12.0
 scikit-learn>=1.3.0
 groq>=0.11
+python-dotenv>=1.0

--- a/src/auris/__main__.py
+++ b/src/auris/__main__.py
@@ -1,3 +1,13 @@
+"""Entry point for `python -m auris`.
+
+Loads a `.env` file from the current working directory (or any parent)
+before delegating to the audit pipeline, so users don't need to
+manually `export` env vars like `GROQ_API_KEY` each shell session.
+"""
+from dotenv import load_dotenv
+
+load_dotenv()
+
 from auris.audit_risk import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Before this PR, every fresh shell needed \`set -a; source .env; set +a\` before \`python -m auris --summarize\` or \`streamlit run app.py\` could read \`GROQ_API_KEY\`. Easy to forget; tripped up the smoke test once already.
- Adds \`python-dotenv>=1.0\` to \`requirements.txt\`. \`src/auris/__main__.py\` and \`app.py\` call \`load_dotenv()\` before importing the rest of the package, so any env var in \`.env\` (or any parent \`.env\`) is on \`os.environ\` by the time \`summarize.py\` checks for \`GROQ_API_KEY\`.
- Library users are unaffected: only the CLI and Streamlit entry points load the file. Importing AuRIS as a library from another project leaves the host's env handling alone.
- README drops the manual \`export\` instruction and documents that \`.env\` is now auto-loaded.

## Test plan
- [ ] CI: pytest matrix green on Python 3.10 / 3.11 / 3.12 with all 24 tests still passing (mock target unchanged).
- [ ] After merge and \`pip install -r requirements.txt\`: \`python -m auris -i data/transactions.csv -o output --summarize -v\` succeeds in a brand-new shell with no manual env export.
- [ ] \`streamlit run app.py\` in a brand-new shell renders and the "Generate AI Summary" button works without manual env export.