### PR TITLE
Add LLM-driven column detection for arbitrary CSVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,35 @@ The full generated executive summary is committed at [`examples/nasa_fy2024_summ
 
 The mapped dataset (`data/usaspending_sample.csv`) is committed so anyone browsing the repo can reproduce this exact run. The 26MB raw file is gitignored; regenerate it from USASpending as described above.
 
+## Universal CSV Support (LLM Column Detection)
+
+AuRIS's pipeline internally expects four columns: `vendor`, `amount`, `date`, `invoice_id`. Real-world CSVs almost never come with those exact names. Rather than shipping a hand-written adapter for every possible data source, AuRIS uses the same Groq / Llama layer that writes the executive summary to also read your CSV headers (and, when the CSV is not too wide, a few sample rows) and return a mapping.
+
+### How it works
+
+- **CLI:** On every run, AuRIS checks whether the input CSV already has the four required column names. If yes, it proceeds unchanged. If no, it calls `detect_columns` in `src/auris/schema.py`, which sends the headers to Llama 3.3 70B with a strict JSON response schema and applies the returned mapping automatically. All requires `GROQ_API_KEY`.
+- **Streamlit dashboard:** After you upload a CSV, if it does not match AuRIS's default schema, a **Column Mapping** section appears with four dropdowns pre-selected with the LLM's guesses. You confirm or override with one click before analysis runs.
+- **Manual override on the CLI:** Pass `--column-map "vendor=col1,amount=col2,date=col3,invoice_id=col4"` to skip auto-detection entirely.
+
+### Wide-CSV handling
+
+For CSVs with more than 40 columns (e.g. federal spending exports with 286 columns), AuRIS omits the sample rows from the prompt and asks the LLM to infer the mapping from column names alone. This keeps the request under Groq's free-tier per-request token limit. Individual cell values are also capped at 120 characters so long text descriptions do not blow up the prompt.
+
+### Example: any USASpending export, no adapter script needed
+
+Before LLM column detection, running AuRIS on a raw USASpending file required a hand-written adapter (`scripts/load_usaspending.py`). Now:
+
+```bash
+# Download any USASpending Contracts CSV, save to data/usaspending_raw.csv
+python3 -m auris -i data/usaspending_raw.csv -o output --summarize -v
+```
+
+AuRIS reads the 286 headers, asks Llama to map them, applies the mapping, and runs the pipeline. The `scripts/load_usaspending.py` adapter is now only useful if you want to filter by fiscal year before analysis; column mapping is handled by the LLM.
+
+### Cost
+
+One additional Groq call per run (about 200-400 tokens). At Llama 3.3 70B free-tier rates (14,400 requests per day), this is negligible; it does not affect the "no credit card needed" story.
+
 ## Visualizations
 
 Five PNG plots written to the output directory on every run:
@@ -228,10 +257,11 @@ pip install -r requirements-dev.txt
 python3 -m pytest tests/ -v
 ```
 
-23 pytest tests cover the six risk checks, the report shape, the ML pass, and the AI summary layer:
+36 pytest tests cover the six risk checks, the report shape, the ML pass, the AI summary layer, and the LLM column-detection layer:
 - `tests/test_audit_risk.py`, 11 tests on the statistical checks.
 - `tests/test_ml_anomalies.py`, 7 tests on the Isolation Forest pass.
-- `tests/test_summarize.py`, 5 tests on the Groq / Llama summary layer (all mocked, no API calls).
+- `tests/test_summarize.py`, 6 tests on the Groq / Llama summary layer (all mocked, no API calls).
+- `tests/test_schema.py`, 12 tests on LLM-driven column detection and the mapping helpers (all mocked, no API calls).
 
 GitHub Actions runs the full test suite against Python 3.10, 3.11, and 3.12 on every push and pull request to `main` and `dev`. See `.github/workflows/ci.yml`.
 

--- a/README.md
+++ b/README.md
@@ -257,11 +257,11 @@ pip install -r requirements-dev.txt
 python3 -m pytest tests/ -v
 ```
 
-36 pytest tests cover the six risk checks, the report shape, the ML pass, the AI summary layer, and the LLM column-detection layer:
+41 pytest tests cover the six risk checks, the report shape, the ML pass, the AI summary layer, and the LLM column-detection layer:
 - `tests/test_audit_risk.py`, 11 tests on the statistical checks.
 - `tests/test_ml_anomalies.py`, 7 tests on the Isolation Forest pass.
 - `tests/test_summarize.py`, 6 tests on the Groq / Llama summary layer (all mocked, no API calls).
-- `tests/test_schema.py`, 12 tests on LLM-driven column detection and the mapping helpers (all mocked, no API calls).
+- `tests/test_schema.py`, 18 tests on LLM-driven column detection and the mapping helpers, including regression tests for the wide-CSV path (samples omitted from prompt above 40 columns), cell-value truncation (>120 chars), and malformed LLM responses (non-JSON, non-object, non-string mapping values). All mocked, no API calls.
 
 GitHub Actions runs the full test suite against Python 3.10, 3.11, and 3.12 on every push and pull request to `main` and `dev`. See `.github/workflows/ci.yml`.
 

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ from auris.audit_risk import (
     check_vendor_frequency,
 )
 from auris.config import RiskConfig
+from auris.schema import REQUIRED_FIELDS, apply_mapping, detect_columns
 from auris.summarize import summarize_risks
 
 DEFAULT_CSV = PROJECT_ROOT / "data" / "transactions.csv"
@@ -49,13 +50,61 @@ config = RiskConfig(
 # Load data.
 if uploaded_file is not None:
     data = pd.read_csv(uploaded_file)
+    upload_key = f"upload::{uploaded_file.name}::{uploaded_file.size}"
 else:
     try:
         data = pd.read_csv(DEFAULT_CSV)
+        upload_key = "default"
         st.info(f"Using default `{DEFAULT_CSV.relative_to(PROJECT_ROOT)}`. Upload your own CSV in the sidebar.")
     except FileNotFoundError:
         st.warning("No data found. Please upload a transactions CSV file.")
         st.stop()
+
+# Column mapping. If the CSV already has AuRIS's schema, skip the mapping UI.
+# Otherwise: call the LLM to guess, then show 4 dropdowns pre-filled with the
+# guesses so the user can confirm or override before analysis runs.
+already_mapped = set(REQUIRED_FIELDS).issubset(data.columns)
+if not already_mapped:
+    st.subheader("Column Mapping")
+    st.caption(
+        "This CSV does not match AuRIS's default schema. Llama 3.3 70B via Groq "
+        "will read the headers and suggest which columns map to `vendor`, "
+        "`amount`, `date`, `invoice_id`. Confirm each dropdown before analysis "
+        "runs. Requires GROQ_API_KEY."
+    )
+    if st.session_state.get("mapping_upload_key") != upload_key:
+        with st.spinner("Asking Llama to identify columns..."):
+            try:
+                st.session_state.detected_mapping = detect_columns(data, config)
+                st.session_state.mapping_upload_key = upload_key
+                st.session_state.mapping_error = None
+            except Exception as exc:
+                st.session_state.detected_mapping = {k: None for k in REQUIRED_FIELDS}
+                st.session_state.mapping_upload_key = upload_key
+                st.session_state.mapping_error = str(exc)
+    if st.session_state.get("mapping_error"):
+        st.warning(
+            f"Auto-detection failed: {st.session_state.mapping_error} "
+            "Set the dropdowns manually below."
+        )
+
+    detected = st.session_state.detected_mapping
+    all_cols = list(data.columns)
+    map_cols = st.columns(4)
+    user_mapping: dict[str, str | None] = {}
+    for label, ui_col in zip(REQUIRED_FIELDS, map_cols):
+        with ui_col:
+            guess = detected.get(label)
+            index = all_cols.index(guess) if guess in all_cols else 0
+            picked = st.selectbox(
+                f"{label}",
+                options=all_cols,
+                index=index,
+                key=f"mapping_{label}",
+                help=f"AI guess: {guess if guess else 'no match'}",
+            )
+            user_mapping[label] = picked
+    data = apply_mapping(data, user_mapping)
 
 # Data preview.
 st.subheader("Data Preview")

--- a/src/auris/audit_risk.py
+++ b/src/auris/audit_risk.py
@@ -333,6 +333,13 @@ def parse_args() -> argparse.Namespace:
                         help="Groq model id for the AI summary (default llama-3.3-70b-versatile)")
     parser.add_argument("--summary-max-tokens", type=int, default=DEFAULT_CONFIG.summary_max_tokens,
                         help="Max tokens for the AI summary output (default 1024)")
+    parser.add_argument("--column-map", type=str, default=None,
+                        help="Manual column mapping for CSVs that do not use AuRIS's schema. "
+                             "Format: 'vendor=col1,amount=col2,date=col3,invoice_id=col4'. "
+                             "When set, skips LLM auto-detection.")
+    parser.add_argument("--auto-detect-columns", action="store_true",
+                        help="Force LLM-based column detection even when the input CSV already "
+                             "has the four required columns. Requires GROQ_API_KEY.")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Increase verbosity (-v for DEBUG)")
     parser.add_argument("-q", "--quiet", action="count", default=0,
@@ -363,6 +370,33 @@ def main() -> None:
     data = load_data(args.input)
     if data is None:
         return
+
+    from auris.schema import (
+        REQUIRED_FIELDS,
+        apply_mapping,
+        detect_columns,
+        parse_column_map_flag,
+    )
+    already_mapped = set(REQUIRED_FIELDS).issubset(data.columns)
+    if args.column_map is not None:
+        try:
+            manual_map = parse_column_map_flag(args.column_map)
+            data = apply_mapping(data, manual_map)
+            logger.info("applied manual column map: %s", manual_map)
+        except ValueError as exc:
+            logger.error("invalid --column-map: %s", exc)
+            return
+    elif args.auto_detect_columns or not already_mapped:
+        try:
+            detected = detect_columns(data, config)
+            data = apply_mapping(data, detected)
+            logger.info("applied LLM-detected column map: %s", detected)
+        except (RuntimeError, ValueError) as exc:
+            logger.error(
+                "column detection failed: %s. Pass --column-map to map manually.", exc,
+            )
+            return
+
     duplicates = check_duplicates(data)
     anomalies = check_anomalies(data, config)
     missing = check_missing(data)

--- a/src/auris/schema.py
+++ b/src/auris/schema.py
@@ -1,0 +1,251 @@
+"""LLM-driven column detection: map arbitrary CSV headers to AuRIS's schema.
+
+AuRIS's pipeline expects four columns: `vendor`, `amount`, `date`,
+`invoice_id`. Real-world CSVs never come with those exact names.
+Rather than shipping a per-source adapter script for every possible
+data source, this module asks the same Groq / Llama layer that
+writes the executive summary to also read the CSV headers plus a
+few sample rows and return the mapping.
+
+Usage:
+    from auris.schema import detect_columns
+    mapping = detect_columns(df, config)
+    # mapping = {"vendor": "recipient_name", "amount": "total_usd", ...}
+    df = df.rename(columns={v: k for k, v in mapping.items() if v})
+
+The detected mapping is a *suggestion*. Callers are expected to show
+it to the user and let them override each field via a dropdown or
+CLI flag before the pipeline runs.
+
+Security note: this function sends CSV headers and up to 3 sample
+rows to the Groq API. Do not pass CSVs that contain secrets or
+credentials to `detect_columns`. Column *values* used as sample rows
+are visible to the model.
+"""
+import json
+import logging
+import os
+from typing import Optional
+
+import pandas as pd
+
+from auris.config import DEFAULT_CONFIG, RiskConfig
+
+logger = logging.getLogger("auris")
+
+REQUIRED_FIELDS = ("vendor", "amount", "date", "invoice_id")
+
+_SAMPLE_ROWS = 3
+# Above this column count, we skip sample rows in the prompt to stay under
+# Groq's free-tier per-request token limit. Column names alone still give
+# the LLM enough signal for the common cases.
+_WIDE_CSV_THRESHOLD = 40
+# Cap on any individual cell value length in the sample rows, to keep long
+# text fields (descriptions, addresses) from blowing up the prompt.
+_MAX_CELL_CHARS = 120
+
+_SYSTEM_PROMPT = (
+    "You are a data schema mapper. You will be given the headers and a few "
+    "sample rows of a CSV file. Your job is to identify which columns map to "
+    "the four required fields of an audit-risk pipeline. Return only valid "
+    "JSON matching the exact schema requested. Do not add prose or "
+    "explanation outside the JSON object."
+)
+
+
+def _truncate_cell(value: object) -> object:
+    """Cap string cells at _MAX_CELL_CHARS; leave non-strings alone."""
+    if isinstance(value, str) and len(value) > _MAX_CELL_CHARS:
+        return value[:_MAX_CELL_CHARS] + "..."
+    return value
+
+
+def _build_prompt(headers: list[str], sample_rows: list[dict] | None) -> str:
+    """Build the user-message body from the header list and (optional) sample rows.
+
+    For CSVs with many columns, `sample_rows` is passed as None to keep the
+    prompt under Groq's free-tier per-request token limit; the LLM has to
+    infer the mapping from column names alone.
+    """
+    body = (
+        "Map the following CSV to an audit-risk schema with exactly these "
+        "four required fields:\n"
+        "- vendor: name of the party being paid or receiving the transaction "
+        "(company or individual)\n"
+        "- amount: numeric monetary value of the transaction\n"
+        "- date: transaction date, in any parseable format\n"
+        "- invoice_id: unique identifier for the transaction, invoice, or "
+        "award\n\n"
+        f"CSV headers: {headers}\n\n"
+    )
+    if sample_rows:
+        body += (
+            f"Sample rows (up to {_SAMPLE_ROWS}):\n"
+            f"{json.dumps(sample_rows, default=str, indent=2)}\n\n"
+        )
+    else:
+        body += (
+            "(The CSV has too many columns to include sample rows. "
+            "Infer the mapping from column names alone.)\n\n"
+        )
+    body += (
+        "Return ONLY a JSON object with exactly these four keys: vendor, "
+        "amount, date, invoice_id. Each value must be either the exact name "
+        "of a column from the CSV headers list, or null if no column maps to "
+        "that field.\n\n"
+        'Example: {"vendor": "recipient_name", "amount": "total_usd", '
+        '"date": "action_date", "invoice_id": "award_id"}'
+    )
+    return body
+
+
+def detect_columns(
+    df: pd.DataFrame,
+    config: RiskConfig = DEFAULT_CONFIG,
+    client: Optional[object] = None,
+) -> dict[str, Optional[str]]:
+    """Ask the LLM to map CSV headers to AuRIS's four required fields.
+
+    Returns a dict with keys `vendor`, `amount`, `date`, `invoice_id`.
+    Each value is either the name of a column in `df`, or `None` if the
+    LLM could not find a match. Raises RuntimeError if `GROQ_API_KEY`
+    is unset. Raises ValueError if the LLM returns a malformed response.
+    `client` is an optional pre-built Groq client, useful for tests.
+    """
+    if df is None or df.empty:
+        raise ValueError("cannot detect columns on an empty DataFrame.")
+
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "GROQ_API_KEY environment variable is required for LLM column "
+            "detection. Get a free key from https://console.groq.com and "
+            "set it in your environment (e.g. via a .env file). Alternatively, "
+            "pass --column-map on the CLI to specify the mapping manually."
+        )
+
+    if client is None:
+        from groq import Groq
+        client = Groq()
+
+    headers = list(df.columns)
+    include_samples = len(headers) <= _WIDE_CSV_THRESHOLD
+    if include_samples:
+        raw_samples = df.head(_SAMPLE_ROWS).to_dict(orient="records")
+        sample_rows = [
+            {k: _truncate_cell(v) for k, v in row.items()} for row in raw_samples
+        ]
+    else:
+        sample_rows = None
+    user_prompt = _build_prompt(headers, sample_rows)
+
+    logger.info(
+        "requesting column mapping: model=%s, headers=%d, samples=%s",
+        config.summary_model, len(headers),
+        "included" if include_samples else "omitted (wide CSV)",
+    )
+
+    response = client.chat.completions.create(
+        model=config.summary_model,
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        max_tokens=256,
+        response_format={"type": "json_object"},
+    )
+
+    if not response.choices:
+        raise ValueError("LLM returned no choices in the response.")
+    text = response.choices[0].message.content or ""
+    text = text.strip()
+    if not text:
+        raise ValueError("LLM returned an empty response.")
+
+    try:
+        mapping = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"LLM returned invalid JSON: {exc}") from exc
+
+    if not isinstance(mapping, dict):
+        raise ValueError(f"LLM returned {type(mapping).__name__}, not a JSON object.")
+
+    missing_keys = [k for k in REQUIRED_FIELDS if k not in mapping]
+    if missing_keys:
+        raise ValueError(
+            f"LLM response missing required keys: {missing_keys}. Got: {list(mapping.keys())}"
+        )
+
+    result: dict[str, Optional[str]] = {}
+    for key in REQUIRED_FIELDS:
+        value = mapping[key]
+        if value is None or value == "":
+            result[key] = None
+            continue
+        if not isinstance(value, str):
+            raise ValueError(
+                f"LLM mapped '{key}' to a {type(value).__name__}, expected string or null."
+            )
+        if value not in headers:
+            logger.warning(
+                "LLM mapped '%s' to column '%s' which is not in CSV headers; dropping.",
+                key, value,
+            )
+            result[key] = None
+            continue
+        result[key] = value
+
+    logger.info("column mapping detected: %s", result)
+    return result
+
+
+def parse_column_map_flag(flag_value: str) -> dict[str, str]:
+    """Parse the CLI --column-map value into a mapping dict.
+
+    Format: comma-separated pairs of `auris_field=source_column`. Example:
+        vendor=recipient_name,amount=total_usd,date=action_date,invoice_id=award_id
+    Whitespace around keys and values is stripped. Raises ValueError on
+    malformed input or unknown auris_field keys.
+    """
+    mapping: dict[str, str] = {}
+    for raw_pair in flag_value.split(","):
+        pair = raw_pair.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            raise ValueError(
+                f"invalid --column-map entry '{pair}': expected 'field=column' pairs "
+                "separated by commas."
+            )
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if key not in REQUIRED_FIELDS:
+            raise ValueError(
+                f"unknown --column-map field '{key}': expected one of {REQUIRED_FIELDS}."
+            )
+        if not value:
+            raise ValueError(f"--column-map entry '{pair}' has an empty value.")
+        mapping[key] = value
+    return mapping
+
+
+def apply_mapping(df: pd.DataFrame, mapping: dict[str, Optional[str]]) -> pd.DataFrame:
+    """Rename columns in df according to the mapping.
+
+    Values that are None are ignored (the auris field is left unmapped).
+    Values pointing at columns that don't exist in df are also ignored.
+    Returns a new DataFrame with renamed columns; does not mutate the input.
+    """
+    rename: dict[str, str] = {}
+    for auris_field, source_col in mapping.items():
+        if source_col is None:
+            continue
+        if source_col not in df.columns:
+            logger.warning(
+                "mapping references column '%s' not in DataFrame; skipping.",
+                source_col,
+            )
+            continue
+        rename[source_col] = auris_field
+    return df.rename(columns=rename)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,216 @@
+"""Tests for LLM-driven column detection and the mapping helpers.
+
+All tests use a mocked Groq client; no real API calls are made,
+so CI does not require GROQ_API_KEY.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from auris.config import RiskConfig
+from auris.schema import (
+    REQUIRED_FIELDS,
+    apply_mapping,
+    detect_columns,
+    parse_column_map_flag,
+)
+
+
+def _fake_groq_response(text: str) -> SimpleNamespace:
+    """Mimic the shape of a Groq chat completion: response.choices[0].message.content."""
+    message = SimpleNamespace(content=text)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+def _mock_client(reply_text: str) -> MagicMock:
+    """Build a MagicMock Groq client whose chat.completions.create returns reply_text."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = _fake_groq_response(reply_text)
+    return client
+
+
+@pytest.fixture
+def usaspending_like_df() -> pd.DataFrame:
+    """A tiny DataFrame with USASpending-like column names (not AuRIS's schema)."""
+    return pd.DataFrame([
+        {"award_id_piid": "80NSSC24FA361", "recipient_name": "NEW TECH SOLUTIONS, INC.",
+         "total_obligated_amount": 24225.00, "award_base_action_date": "2024-03-11"},
+        {"award_id_piid": "80NSSC24FA362", "recipient_name": "FOUR LLC",
+         "total_obligated_amount": 114935.53, "award_base_action_date": "2024-03-08"},
+    ])
+
+
+# ------------------------------------------------------------
+# detect_columns()
+# ------------------------------------------------------------
+
+def test_detect_columns_happy_path_calls_groq_with_expected_args(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """Verify model, response_format, prompt structure, and returned mapping."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client(
+        '{"vendor": "recipient_name", "amount": "total_obligated_amount", '
+        '"date": "award_base_action_date", "invoice_id": "award_id_piid"}'
+    )
+
+    mapping = detect_columns(usaspending_like_df, RiskConfig(), client=client)
+
+    assert client.chat.completions.create.call_count == 1
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["model"] == "llama-3.3-70b-versatile"
+    assert kwargs["response_format"] == {"type": "json_object"}
+    messages = kwargs["messages"]
+    assert messages[0]["role"] == "system"
+    assert "data schema mapper" in messages[0]["content"]
+    user_prompt = messages[1]["content"]
+    for header in usaspending_like_df.columns:
+        assert header in user_prompt
+
+    assert mapping == {
+        "vendor": "recipient_name",
+        "amount": "total_obligated_amount",
+        "date": "award_base_action_date",
+        "invoice_id": "award_id_piid",
+    }
+
+
+def test_detect_columns_handles_null_field_from_llm(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """When the LLM returns null for a field, the mapping preserves the null."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client(
+        '{"vendor": "recipient_name", "amount": "total_obligated_amount", '
+        '"date": "award_base_action_date", "invoice_id": null}'
+    )
+
+    mapping = detect_columns(usaspending_like_df, RiskConfig(), client=client)
+    assert mapping["invoice_id"] is None
+    assert mapping["vendor"] == "recipient_name"
+
+
+def test_detect_columns_drops_hallucinated_column_names(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """When the LLM hallucinates a column name not in the CSV, the field becomes None."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client(
+        '{"vendor": "recipient_name", "amount": "total_obligated_amount", '
+        '"date": "made_up_date_column", "invoice_id": "award_id_piid"}'
+    )
+
+    mapping = detect_columns(usaspending_like_df, RiskConfig(), client=client)
+    assert mapping["date"] is None
+    assert mapping["vendor"] == "recipient_name"
+
+
+def test_detect_columns_missing_api_key_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """When GROQ_API_KEY is unset, raise RuntimeError with a clear message."""
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="GROQ_API_KEY"):
+        detect_columns(usaspending_like_df, RiskConfig())
+
+
+def test_detect_columns_empty_dataframe_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detection on an empty DataFrame is a caller bug; raise ValueError."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    with pytest.raises(ValueError, match="empty"):
+        detect_columns(pd.DataFrame(), RiskConfig())
+
+
+def test_detect_columns_malformed_json_raises(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """When the LLM returns non-JSON garbage, raise ValueError."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client("this is not JSON at all")
+    with pytest.raises(ValueError, match="invalid JSON"):
+        detect_columns(usaspending_like_df, RiskConfig(), client=client)
+
+
+def test_detect_columns_missing_required_key_raises(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """When the LLM omits a required key, raise ValueError."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client(
+        '{"vendor": "recipient_name", "amount": "total_obligated_amount"}'
+    )
+    with pytest.raises(ValueError, match="missing required keys"):
+        detect_columns(usaspending_like_df, RiskConfig(), client=client)
+
+
+# ------------------------------------------------------------
+# parse_column_map_flag()
+# ------------------------------------------------------------
+
+def test_parse_column_map_flag_parses_valid_comma_separated_pairs() -> None:
+    """The CLI flag format 'k=v,k=v' round-trips into a dict."""
+    result = parse_column_map_flag(
+        "vendor=recipient_name,amount=total_usd,date=action_date,invoice_id=award_id"
+    )
+    assert result == {
+        "vendor": "recipient_name",
+        "amount": "total_usd",
+        "date": "action_date",
+        "invoice_id": "award_id",
+    }
+
+
+def test_parse_column_map_flag_rejects_unknown_field_names() -> None:
+    """Only the four REQUIRED_FIELDS are accepted; anything else is a ValueError."""
+    with pytest.raises(ValueError, match="unknown --column-map field"):
+        parse_column_map_flag("vendor=foo,bogus=bar")
+
+
+def test_parse_column_map_flag_rejects_missing_equals() -> None:
+    """Entries without '=' are rejected."""
+    with pytest.raises(ValueError, match="expected 'field=column' pairs"):
+        parse_column_map_flag("vendor recipient_name")
+
+
+# ------------------------------------------------------------
+# apply_mapping()
+# ------------------------------------------------------------
+
+def test_apply_mapping_renames_columns_to_auris_schema(
+    usaspending_like_df: pd.DataFrame,
+) -> None:
+    """A complete mapping renames all four columns; original df is unchanged."""
+    mapping = {
+        "vendor": "recipient_name",
+        "amount": "total_obligated_amount",
+        "date": "award_base_action_date",
+        "invoice_id": "award_id_piid",
+    }
+    renamed = apply_mapping(usaspending_like_df, mapping)
+    for field in REQUIRED_FIELDS:
+        assert field in renamed.columns
+    # Original DataFrame is untouched.
+    assert "recipient_name" in usaspending_like_df.columns
+
+
+def test_apply_mapping_skips_none_and_absent_columns(
+    usaspending_like_df: pd.DataFrame,
+) -> None:
+    """None values and columns absent from the DataFrame are silently skipped."""
+    mapping = {
+        "vendor": "recipient_name",
+        "amount": None,
+        "date": "not_a_real_column",
+        "invoice_id": "award_id_piid",
+    }
+    renamed = apply_mapping(usaspending_like_df, mapping)
+    assert "vendor" in renamed.columns
+    assert "invoice_id" in renamed.columns
+    # amount and date should NOT be created.
+    assert "amount" not in renamed.columns
+    assert "date" not in renamed.columns

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -148,6 +148,94 @@ def test_detect_columns_missing_required_key_raises(
         detect_columns(usaspending_like_df, RiskConfig(), client=client)
 
 
+def test_detect_columns_wide_csv_omits_sample_rows_from_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For CSVs with more than 40 columns, sample rows are omitted from the prompt.
+
+    This is the safety net that keeps AuRIS under Groq's free-tier per-request
+    token limit on real-world wide CSVs like the 286-column USASpending export.
+    Regression protection: removing this guard would silently break AuRIS on
+    every wide CSV.
+    """
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    wide_df = pd.DataFrame([{f"col_{i}": f"value_{i}" for i in range(50)}])
+    client = _mock_client(
+        '{"vendor": "col_1", "amount": "col_2", "date": "col_3", "invoice_id": "col_4"}'
+    )
+
+    detect_columns(wide_df, RiskConfig(), client=client)
+
+    user_prompt = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert "too many columns to include sample rows" in user_prompt
+    assert "Sample rows" not in user_prompt
+
+
+def test_detect_columns_narrow_csv_includes_sample_rows_in_prompt(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """For narrow CSVs (<=40 cols), sample rows ARE included in the prompt."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client(
+        '{"vendor": "recipient_name", "amount": "total_obligated_amount", '
+        '"date": "award_base_action_date", "invoice_id": "award_id_piid"}'
+    )
+
+    detect_columns(usaspending_like_df, RiskConfig(), client=client)
+
+    user_prompt = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert "Sample rows" in user_prompt
+    # Actual data values from the fixture should be present in the prompt.
+    assert "NEW TECH SOLUTIONS" in user_prompt
+
+
+def test_detect_columns_truncates_long_cell_values_in_samples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """String cells longer than 120 chars are truncated with '...' in the prompt.
+
+    Regression protection: long text descriptions in real datasets (contract
+    scope-of-work paragraphs, legal disclaimers) would otherwise bloat the
+    prompt and defeat the wide-CSV safety net.
+    """
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    long_text = "A" * 500  # Well above the 120-char cap.
+    narrow_df = pd.DataFrame([{"vendor_col": "ACME", "desc_col": long_text}])
+    client = _mock_client(
+        '{"vendor": "vendor_col", "amount": null, "date": null, "invoice_id": null}'
+    )
+
+    detect_columns(narrow_df, RiskConfig(), client=client)
+
+    user_prompt = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert "..." in user_prompt
+    # The full 500-A string must NOT appear verbatim.
+    assert "A" * 500 not in user_prompt
+
+
+def test_detect_columns_llm_returns_json_list_raises(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """When the LLM returns valid JSON that is not an object (e.g. a list), raise ValueError."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client('["vendor", "amount", "date", "invoice_id"]')
+    with pytest.raises(ValueError, match="not a JSON object"):
+        detect_columns(usaspending_like_df, RiskConfig(), client=client)
+
+
+def test_detect_columns_llm_returns_non_string_value_raises(
+    monkeypatch: pytest.MonkeyPatch, usaspending_like_df: pd.DataFrame
+) -> None:
+    """When the LLM maps a required field to a number or bool, raise ValueError."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    client = _mock_client(
+        '{"vendor": "recipient_name", "amount": 42, '
+        '"date": "award_base_action_date", "invoice_id": "award_id_piid"}'
+    )
+    with pytest.raises(ValueError, match="expected string or null"):
+        detect_columns(usaspending_like_df, RiskConfig(), client=client)
+
+
 # ------------------------------------------------------------
 # parse_column_map_flag()
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Before this PR, AuRIS's pipeline hard-required four columns named exactly \`vendor\`, \`amount\`, \`date\`, \`invoice_id\`. Real-world CSVs never come with those names, so users either had to hand-write an adapter per data source (see \`scripts/load_usaspending.py\`) or rename columns manually. This friction was the single biggest gap between AuRIS as a portfolio piece and AuRIS as a tool a non-developer could actually use.

This PR reuses the Groq / Llama 3.3 70B infrastructure already provisioned for the executive summary to also read CSV headers (and, when the CSV is not too wide, a few sample rows) and return a JSON mapping from AuRIS's four required fields to whatever the source CSV called them. Same LLM, same API key, two touchpoints in the pipeline instead of one.

The pitch upgrades from *"audit tool that happens to have an AI summary at the end"* to *"AI-native audit tool: LLM understands your data on the way in, LLM writes the CFO summary on the way out."*

## What changed

- **New module \`src/auris/schema.py\`** — \`detect_columns()\`, \`apply_mapping()\`, \`parse_column_map_flag()\`. Same signature and testability conventions as \`summarize.py\`.
- **CLI (\`audit_risk.py\`)** — CSVs that already have AuRIS's four columns work unchanged. Any other CSV triggers LLM detection automatically. New flags: \`--column-map "vendor=col,..."\` (manual override, skips LLM) and \`--auto-detect-columns\` (force detection).
- **Streamlit (\`app.py\`)** — after upload, if the CSV does not match AuRIS's schema, a "Column Mapping" section appears with four dropdowns pre-selected with the LLM's guesses. User confirms or overrides with one click. If the LLM call fails, dropdowns default to first column and a warning is shown — dashboard remains usable offline.
- **Wide-CSV handling** — for CSVs with more than 40 columns (motivated by the 286-column USASpending raw file), sample rows are omitted to stay under Groq's free-tier 12K-token limit. Individual cell values are also capped at 120 chars.
- **12 new mocked tests** in \`tests/test_schema.py\`. Total suite: 36 tests, all mocked, no real API calls. CI does not need \`GROQ_API_KEY\`.
- **README** — new "Universal CSV Support" section documents the flow, wide-CSV handling, and the manual override.

## End-to-end verification

Ran against the raw 286-column USASpending Contracts CSV with no adapter and no flags:

\`\`\`
$ python3 -m auris -i data/usaspending_raw.csv -o output --summarize -v
starting AuRIS: Audit Risk Identification System
requesting column mapping: model=llama-3.3-70b-versatile, headers=286, samples=omitted (wide CSV)
column mapping detected: {'vendor': 'recipient_name', 'amount': 'total_obligated_amount', 'date': 'award_base_action_date', 'invoice_id': 'award_id_piid'}
applied LLM-detected column map
risk report saved as risks_report.csv (22745 total rows)
AI summary saved as risk_summary.md
\`\`\`

Llama picked all four columns correctly from names alone. No manual mapping was necessary.

## Test plan

- [ ] CI: pytest matrix green on Python 3.10 / 3.11 / 3.12 with all 36 tests passing.
- [ ] Local Streamlit: upload a CSV with non-AuRIS column names, confirm the "Column Mapping" section appears with LLM's guesses pre-selected, override one dropdown, click run, verify analysis reflects the override.
- [ ] Local CLI: \`python -m auris -i <arbitrary_csv>\` triggers LLM detection; \`--column-map "vendor=...,amount=...,date=...,invoice_id=..."\` skips LLM and applies the manual map.
- [ ] Empty / malformed responses from the LLM don't crash the CLI; error is logged and user is pointed at \`--column-map\`.