### PR TITLE
Fix Streamlit Cloud deployment: install AuRIS package via requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      - name: Install AuRIS in editable mode
-        run: pip install -e . --no-deps
-
       - name: Run test suite
         run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -177,13 +177,12 @@ source venv/bin/activate     # On Windows: venv\Scripts\activate
 
 ### Install
 ```bash
-pip install -r requirements.txt           # Engine only
-pip install -r requirements-dev.txt       # Engine + pytest
-pip install -r requirements-app.txt       # Engine + Streamlit dashboard
-pip install -e .                          # Install AuRIS itself in editable mode
+pip install -r requirements.txt           # Engine + AuRIS package
+pip install -r requirements-dev.txt       # Engine + AuRIS + pytest
+pip install -r requirements-app.txt       # Engine + AuRIS + Streamlit dashboard
 ```
 
-The final `pip install -e .` step (powered by `pyproject.toml`) makes `auris` importable from anywhere and registers the `auris` console script, so `python -m auris ...` and `streamlit run app.py` work without manual `PYTHONPATH=src` prefixes.
+Each `requirements-*.txt` file installs AuRIS itself (via `pyproject.toml`) alongside its dependencies. `python -m auris ...` and `streamlit run app.py` work from any directory afterwards. For local development against a live source tree, use `pip install -e .` instead to install AuRIS in editable mode.
 
 ### Optional: generate a synthetic dataset
 A seeded 10K-row generator with injected duplicates and outliers is included:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,17 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Amrit Dhandharia" }]
 license = { text = "MIT" }
-dynamic = ["dependencies"]
+dependencies = [
+    "pandas>=2.0.0",
+    "matplotlib>=3.7.0",
+    "seaborn>=0.12.0",
+    "scikit-learn>=1.3.0",
+    "groq>=0.11",
+    "python-dotenv>=1.0",
+]
 
 [project.scripts]
 auris = "auris.audit_risk:main"
-
-[tool.setuptools.dynamic]
-dependencies = { file = ["requirements.txt"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ seaborn>=0.12.0
 scikit-learn>=1.3.0
 groq>=0.11
 python-dotenv>=1.0
+.


### PR DESCRIPTION
## Summary

Streamlit Cloud runs \`pip install -r requirements.txt\` and then \`streamlit run app.py\`. It does NOT run \`pip install -e .\` (the step we added in PR #15 to make the src-layout package importable). Without this fix, the first \`from auris.audit_risk import ...\` line in \`app.py\` hits \`ModuleNotFoundError\` and the deploy crashes at startup.

## Changes

1. **\`requirements.txt\`** now ends with \`.\` — pip installs the current directory as a package via \`pyproject.toml\`, so \`import auris\` works after a plain \`pip install -r requirements.txt\`. Also simplifies the local dev flow (no separate \`pip install -e .\` step needed for basic use).
2. **\`pyproject.toml\`** no longer uses \`dynamic = ["dependencies"]\` reading from \`requirements.txt\`. With \`.\` present in \`requirements.txt\`, setuptools's file-based dep parser choked on it (not a valid PEP 508 specifier). Deps hardcoded in \`pyproject.toml\` now, matching \`requirements.txt\`. Small duplication accepted in exchange for reliable installs on any host.
3. **\`.github/workflows/ci.yml\`** drops the now-redundant \`pip install -e . --no-deps\` step. The requirements install handles it.
4. **\`README\`** install section updated: \`pip install -r requirements-app.txt\` is now sufficient to run the Streamlit dashboard end to end.

## Verification

- Fresh venv: \`pip install -r requirements.txt\` → \`import auris\` and all submodules resolve cleanly.
- Streamlit-simulated venv (streamlit + requirements.txt): both packages coexist and import cleanly.
- All 41 existing tests pass locally on Python 3.10.

## Test plan
- [ ] CI matrix green on Python 3.10 / 3.11 / 3.12 with all 41 tests still passing.
- [ ] After merge and re-triggering the Streamlit Cloud deploy, the app starts without ModuleNotFoundError.