### PR TITLE
Hotfix: pyarrow.ArrowInvalid on wide CSVs with mixed-type columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,6 +35,23 @@ from auris.summarize import summarize_risks
 DEFAULT_CSV = PROJECT_ROOT / "data" / "transactions.csv"
 NASA_CSV = PROJECT_ROOT / "data" / "usaspending_sample.csv"
 
+
+def safe_for_arrow(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy safe to hand to st.dataframe.
+
+    Streamlit serialises DataFrames via pyarrow. Columns with mixed
+    Python types (numbers + strings + NaN, common in real-world CSVs
+    like USASpending) trigger pyarrow.ArrowInvalid on serialization.
+    This helper casts every `object`-dtype column to string so the
+    display works regardless of what the source CSV contained.
+    """
+    if df is None or df.empty:
+        return df
+    obj_cols = df.select_dtypes(include=["object"]).columns
+    if len(obj_cols) == 0:
+        return df
+    return df.astype({col: "string" for col in obj_cols})
+
 st.set_page_config(
     page_title="AuRIS - Audit Risk Identification System",
     page_icon=":mag:",
@@ -366,7 +383,7 @@ with tab_findings:
         )
         filtered = report[report["risk_type"].isin(risk_filter)]
         st.caption(f"Showing {len(filtered):,} of {len(report):,} flagged rows.")
-        st.dataframe(filtered, use_container_width=True, hide_index=True)
+        st.dataframe(safe_for_arrow(filtered), use_container_width=True, hide_index=True)
         csv_bytes = filtered.to_csv(index=False).encode("utf-8")
         st.download_button(
             ":arrow_down: Download filtered report as CSV",


### PR DESCRIPTION
## Summary

The live deploy at \`aurisnow.streamlit.app\` crashes when a user uploads a wide CSV with Python-object-dtype columns that hold mixed values (numbers + strings + NaN — the exact shape of the raw 286-column USASpending export the user tried).

Streamlit serialises DataFrames via pyarrow for \`st.dataframe\` display, and pyarrow's inference chokes on those columns:

    pyarrow.lib.ArrowInvalid: Could not convert ...

The failure cascades into "Updating the app files has failed" from Streamlit Cloud and takes the deploy down.

PR #20 (the UI revamp) shipped without this fix because I raced the merge. This PR is the small, cherry-picked hotfix.

## Fix

- New helper \`safe_for_arrow(df)\` in \`app.py\` casts every object-dtype column to pandas \`string\` before display. Applied to the one \`st.dataframe\` call in the Findings tab (the only place a report-derived DataFrame is rendered).

Verified against the raw USASpending CSV (11K rows, 286 columns, 252 object-dtype columns): \`pyarrow.Table.from_pandas\` serialises cleanly after the cast. All 41 existing tests still pass.

## Test plan
- [ ] CI green on Python 3.10 / 3.11 / 3.12.
- [ ] After merge, Streamlit Cloud auto-redeploys and \`aurisnow.streamlit.app\` accepts wide-CSV uploads (test with \`data/usaspending_sample.csv\` from the repo, or the raw USASpending export).
- [ ] Findings tab renders the flagged-transactions table with no ArrowInvalid.