### PR TITLE
Level 2: risk scoring engine (0-100 per row + reason codes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,45 @@ The full generated executive summary is committed at [`examples/nasa_fy2024_summ
 
 The mapped dataset (`data/usaspending_sample.csv`) is committed so anyone browsing the repo can reproduce this exact run. The 26MB raw file is gitignored; regenerate it from USASpending as described above.
 
+## Risk Scoring (Level 2)
+
+Raw check output is a flat list of flagged rows tagged with `risk_type`. On real-world data those lists overlap heavily and don't tell an auditor which of the thousands of flagged rows to look at first. **Risk scoring collapses the overlap into a triage queue.**
+
+`src/auris/scoring.py::score_report(report, config)` takes the concatenated report and returns a DataFrame where:
+
+- Each source transaction (identified by `invoice_id`) appears exactly once.
+- `risk_score` (0-100) is the sum of the weights of every check that fired on the row, capped at 100.
+- `reasons` is the sorted list of check names that contributed.
+- Rows are sorted by score descending, so the caller gets a ready-made triage queue.
+
+### Weights (tunable via `RiskConfig`)
+
+Default weights sum to 100 so a row flagged by every check maxes the scale:
+
+| Check | Weight | Rationale |
+|---|---|---|
+| Duplicate | 25 | Highest-signal audit finding (real double-payments). |
+| Anomaly | 20 | Statistical outlier by amount. |
+| Amount Deviation | 15 | Per-vendor outlier. |
+| ML Anomaly | 20 | Multivariate pattern the statistical checks miss. |
+| Missing Data | 10 | Hygiene signal, not fraud. |
+| High Frequency | 10 | Noisy on skewed real data; kept low intentionally. |
+
+Override any weight via `RiskConfig(duplicate_weight=..., ...)`.
+
+### Where scoring appears
+
+- **CLI:** `python -m auris ... --summarize` writes `risks_scored.csv` alongside `risks_report.csv`. The AI summary consumes the scored view so its Priority Actions can name specific high-scoring rows.
+- **Streamlit dashboard:** a "Priority queue" metric card shows the count of rows with score ≥ 50 (typically ≥ 3 checks fired). The Findings tab shows the scored triage queue with a score-cutoff slider and a per-check filter based on the `reasons` column.
+- **Library:** `from auris.scoring import score_report`.
+
+### Example on the bundled NASA FY2024 slice
+
+Running scoring on `data/usaspending_sample.csv`:
+
+- 2,036 raw check hits collapse to 1,660 scored unique rows.
+- Top-scored rows (score 65) name specific vendors and describe which checks fired, e.g. `Caltech, $87M, [Amount Deviation, Anomaly, High Frequency, ML Anomaly]`.
+
 ## Universal CSV Support (LLM Column Detection)
 
 AuRIS's pipeline internally expects four columns: `vendor`, `amount`, `date`, `invoice_id`. Real-world CSVs almost never come with those exact names. Rather than shipping a hand-written adapter for every possible data source, AuRIS uses the same Groq / Llama layer that writes the executive summary to also read your CSV headers (and, when the CSV is not too wide, a few sample rows) and return a mapping.
@@ -256,11 +295,12 @@ pip install -r requirements-dev.txt
 python3 -m pytest tests/ -v
 ```
 
-41 pytest tests cover the six risk checks, the report shape, the ML pass, the AI summary layer, and the LLM column-detection layer:
+52 pytest tests cover the six risk checks, the report shape, the ML pass, the AI summary layer, the LLM column-detection layer, and the risk-scoring engine:
 - `tests/test_audit_risk.py`, 11 tests on the statistical checks.
 - `tests/test_ml_anomalies.py`, 7 tests on the Isolation Forest pass.
 - `tests/test_summarize.py`, 6 tests on the Groq / Llama summary layer (all mocked, no API calls).
 - `tests/test_schema.py`, 18 tests on LLM-driven column detection and the mapping helpers, including regression tests for the wide-CSV path (samples omitted from prompt above 40 columns), cell-value truncation (>120 chars), and malformed LLM responses (non-JSON, non-object, non-string mapping values). All mocked, no API calls.
+- `tests/test_scoring.py`, 11 tests on the risk-scoring engine: deduplication by `invoice_id`, weight summation, score cap at 100, sort order, custom-weight overrides, empty input, unknown risk-type warnings, missing-invoice-id fallback, and the top-N helper.
 
 GitHub Actions runs the full test suite against Python 3.10, 3.11, and 3.12 on every push and pull request to `main` and `dev`. See `.github/workflows/ci.yml`.
 
@@ -315,7 +355,7 @@ AuRIS/
 AuRIS is being built up in five public, shippable levels. Each level is a separate PR, leaves the existing test suite green, and adds a new capability without rewriting the engine.
 
 1. **AI summary layer.** Shipped. Llama 3.3 70B via Groq, opt-in via `--summarize`, surfaced as a "Generate AI Summary" button in the Streamlit dashboard. See [AI-Augmented Summaries](#ai-augmented-summaries) above.
-2. **Risk scoring engine.** Replace binary flags with a 0-100 numeric risk score per row plus explicit reason codes, weighted across all six checks.
+2. **Risk scoring engine.** Shipped. 0-100 numeric risk score per row plus `reasons` list, weighted across all six checks. See [Risk Scoring (Level 2)](#risk-scoring-level-2) above. Dashboard's Findings tab is now a triage queue sorted by score; AI summary consumes the top-N by score for sharper Priority Actions.
 3. **Full-stack conversion.** FastAPI backend wrapping the Python engine, Next.js 15 + TypeScript + shadcn frontend, deployed to Vercel and Railway with a live demo URL.
 4. **Persistence, auth, and run history.** Supabase Postgres for multi-tenant run storage, magic-link auth, sharable read-only run URLs, and a side-by-side run comparison view.
 5. **ERP integration and production polish.** Pull transactions from Tally, Zoho Books, or ERPNext on a schedule; add Sentry + PostHog observability; ship a public landing page.

--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from auris.audit_risk import (
 )
 from auris.config import RiskConfig
 from auris.schema import REQUIRED_FIELDS, apply_mapping, detect_columns
+from auris.scoring import format_reasons, score_report
 from auris.summarize import summarize_risks
 
 DEFAULT_CSV = PROJECT_ROOT / "data" / "transactions.csv"
@@ -255,13 +256,18 @@ with st.status("Analysing your CSV...", expanded=True) as status:
         [duplicates, anomalies, missing, frequent_vendors, amount_deviations],
         ignore_index=True,
     )
-    # `report` contains one row PER (row, check) pair, so a row flagged
-    # by three checks appears three times. For the "% of dataset"
-    # signal-vs-noise heuristic, count each source row at most once.
-    if not report.empty and "invoice_id" in report.columns:
-        unique_rows_flagged = report["invoice_id"].nunique()
-    else:
-        unique_rows_flagged = len(report)
+    # Level 2 scoring: collapse overlapping check-hits into one scored row
+    # per source transaction. Everything downstream (metric card, Findings
+    # tab, AI summary) reads from the scored triage queue.
+    st.write("📊 Scoring rows across all checks (Level 2)...")
+    scored = score_report(report, config)
+    if not scored.empty:
+        st.write(
+            f"✅ Scored {len(scored):,} unique rows. "
+            f"Top score {float(scored['risk_score'].max()):.0f}/100, "
+            f"median {float(scored['risk_score'].median()):.0f}/100."
+        )
+    unique_rows_flagged = len(scored)
     status.update(
         label=f"✅ Analysis complete: {unique_rows_flagged:,} unique rows flagged ({len(report):,} check hits across 5 checks). Click to review each stage.",
         state="complete",
@@ -283,8 +289,22 @@ else:
     flag_delta = f"{flag_pct:.1f}% of dataset - thresholds too aggressive, tighten sliders"
     flag_color = "inverse"
 
+_PRIORITY_CUTOFF = 50
+priority_pool = scored[scored["risk_score"] >= _PRIORITY_CUTOFF] if not scored.empty else scored
+priority_count = len(priority_pool)
+
 metric_cols = st.columns(4)
-metric_cols[0].metric("Total transactions", f"{len(data):,}")
+metric_cols[0].metric(
+    "Priority queue",
+    f"{priority_count:,}",
+    delta=f"score ≥ {_PRIORITY_CUTOFF}/100 - look at these first",
+    delta_color="normal",
+    help=(
+        "The rows worth investigating first. Score aggregates the weights of "
+        "every risk check that fired on the row (0-100 scale). A score of 50 "
+        f"typically means at least 3 checks fired. Tune weights on RiskConfig."
+    ),
+)
 metric_cols[1].metric(
     "Rows flagged (unique)",
     f"{unique_rows_flagged:,}",
@@ -485,23 +505,48 @@ with tab_overview:
                 st.empty()
 
 with tab_findings:
-    st.subheader("Flagged transactions")
-    if report.empty:
+    st.subheader("Triage queue")
+    st.caption(
+        "Rows sorted by risk score (0-100). Score is the weighted sum of the checks that fired: "
+        "Duplicate 25, Anomaly 20, Amount Deviation 15, Missing 10, Frequency 10, ML 20 (defaults). "
+        "Investigate top-scored rows first; below score 30 is usually low-signal."
+    )
+    if scored.empty:
         st.success("No risks detected under the current thresholds. Loosen the sidebar sliders for a wider net.")
     else:
-        risk_filter = st.multiselect(
-            "Filter by risk type",
-            options=report["risk_type"].unique().tolist(),
-            default=report["risk_type"].unique().tolist(),
-        )
-        filtered = report[report["risk_type"].isin(risk_filter)]
-        st.caption(f"Showing {len(filtered):,} of {len(report):,} flagged rows.")
-        st.dataframe(safe_for_arrow(filtered), use_container_width=True, hide_index=True)
-        csv_bytes = filtered.to_csv(index=False).encode("utf-8")
+        all_check_names = sorted({r for reasons in scored["reasons"] for r in reasons})
+        min_score = int(scored["risk_score"].min())
+        max_score = int(scored["risk_score"].max())
+        col_score, col_checks = st.columns([1, 2])
+        with col_score:
+            score_cutoff = st.slider(
+                "Minimum risk score",
+                min_value=0, max_value=100, value=max(min_score, 30),
+                help="Only show rows scoring at least this. Slide to 0 to see everything.",
+            )
+        with col_checks:
+            check_filter = st.multiselect(
+                "Include rows where these checks fired",
+                options=all_check_names,
+                default=all_check_names,
+            )
+
+        def _row_matches(reasons_list) -> bool:
+            return any(r in check_filter for r in reasons_list)
+
+        filtered = scored[scored["risk_score"] >= score_cutoff]
+        filtered = filtered[filtered["reasons"].apply(_row_matches)]
+
+        display_df = filtered.copy()
+        display_df["reasons"] = display_df["reasons"].apply(format_reasons)
+
+        st.caption(f"Showing {len(filtered):,} of {len(scored):,} scored rows.")
+        st.dataframe(safe_for_arrow(display_df), use_container_width=True, hide_index=True)
+        csv_bytes = display_df.to_csv(index=False).encode("utf-8")
         st.download_button(
-            "⬇️ Download filtered report as CSV",
+            "⬇️ Download triage queue as CSV",
             csv_bytes,
-            "risks_report.csv",
+            "risks_scored.csv",
             "text/csv",
             use_container_width=True,
         )
@@ -515,7 +560,9 @@ with tab_summary:
     if st.button("🤖 Generate AI Summary", type="primary", use_container_width=True):
         with st.spinner("Asking Llama 3.3 70B to summarise the risks..."):
             try:
-                st.session_state["risk_summary_md"] = summarize_risks(report, config)
+                st.session_state["risk_summary_md"] = summarize_risks(
+                    report, config, scored=scored,
+                )
             except RuntimeError as exc:
                 st.error(str(exc))
             except Exception as exc:

--- a/src/auris/audit_risk.py
+++ b/src/auris/audit_risk.py
@@ -441,10 +441,28 @@ def main() -> None:
     plot_risk_distribution(report, output_dir)
     plot_vendor_date_heatmap(data, output_dir)
 
+    # Level 2: score the report and write the ranked triage queue alongside
+    # the flat report. Downstream (AI summary, dashboard) reads the scored
+    # version so priority actions are based on aggregated risk, not raw
+    # check-hit counts.
+    from auris.scoring import score_report
+    scored = score_report(report, config)
+    if not scored.empty:
+        scored_path = output_dir / "risks_scored.csv"
+        scored_for_csv = scored.copy()
+        scored_for_csv["reasons"] = scored_for_csv["reasons"].apply(
+            lambda rs: "; ".join(rs) if isinstance(rs, (list, tuple)) else str(rs)
+        )
+        scored_for_csv.to_csv(scored_path, index=False)
+        logger.info(
+            "scored triage queue saved as risks_scored.csv (%d unique rows)",
+            len(scored),
+        )
+
     if args.summarize:
         from auris.summarize import summarize_risks
         try:
-            summary_md = summarize_risks(report, config)
+            summary_md = summarize_risks(report, config, scored=scored)
             (output_dir / "risk_summary.md").write_text(summary_md, encoding="utf-8")
             logger.info("AI summary saved as risk_summary.md")
         except (RuntimeError, ValueError) as exc:

--- a/src/auris/config.py
+++ b/src/auris/config.py
@@ -11,13 +11,20 @@ AuRIS's defaults aim for the 5 percent zone on typical CSVs. Users
 who want a wider net (early-stage screening) can loosen the sliders
 in the sidebar; users who want a tighter net (senior auditor's
 follow-up pool) can tighten them.
+
+Level 2 (risk scoring): each of the six risk checks has a weight
+that contributes to a per-row score (0 to 100). Defaults are
+calibrated so a row flagged by every check maxes the scale, and so
+the "loud" checks (Duplicate, Anomaly, ML) contribute more than the
+"noisy" checks (High Frequency, Missing Data) that fire on wide
+real-world CSVs.
 """
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
 class RiskConfig:
-    """Thresholds for the statistical, ML, and AI-summary risk checks.
+    """Thresholds and scoring weights for the AuRIS risk checks.
 
     Attributes:
         anomaly_quantile: Quantile of `amount` above which a row is flagged
@@ -44,6 +51,23 @@ class RiskConfig:
             Default "llama-3.3-70b-versatile" (free tier).
         summary_max_tokens: Hard cap on summary output length in tokens.
             Default 1024.
+        duplicate_weight: Points contributed to the risk score when a row
+            is flagged by the Duplicate check. Default 25. Duplicates are
+            the highest-signal audit finding (real double-payments).
+        anomaly_weight: Points for the high-value Anomaly check. Default 20.
+        deviation_weight: Points for the per-vendor Amount Deviation check.
+            Default 15.
+        missing_weight: Points for the Missing Data check. Default 10
+            (data-hygiene signal, not fraud).
+        frequency_weight: Points for the High Frequency (top vendor) check.
+            Default 10 (noisy on skewed real data; kept low intentionally).
+        ml_weight: Points for the Isolation Forest ML Anomaly check.
+            Default 20 (catches multivariate patterns the statistical
+            checks miss).
+
+    Weights sum to 100 by default, so a row flagged by every check
+    scores 100. Users can override any weight via the RiskConfig
+    constructor; scoring caps the per-row total at 100.
     """
 
     anomaly_quantile: float = 0.99
@@ -55,6 +79,14 @@ class RiskConfig:
     ml_random_state: int = 42
     summary_model: str = "llama-3.3-70b-versatile"
     summary_max_tokens: int = 1024
+
+    # Level 2 scoring weights (0-100 per row, sum of contributing checks).
+    duplicate_weight: float = 25.0
+    anomaly_weight: float = 20.0
+    deviation_weight: float = 15.0
+    missing_weight: float = 10.0
+    frequency_weight: float = 10.0
+    ml_weight: float = 20.0
 
 
 DEFAULT_CONFIG = RiskConfig()

--- a/src/auris/scoring.py
+++ b/src/auris/scoring.py
@@ -1,0 +1,161 @@
+"""Weighted risk scoring on top of the six risk checks.
+
+The five statistical checks plus the Isolation Forest ML check each
+produce a flat list of flagged rows tagged with a `risk_type`. On
+real-world data those lists overlap heavily: a Fortune 500 defense
+contractor gets flagged by High Frequency, its largest contracts
+also fire the Anomaly check, and both fire again in the ML pass.
+The result is a report where the same source row appears multiple
+times, and where "top by amount" is a bad triage signal (a $22B
+Boeing contract shows up first even if a $500 duplicate payment is
+a stronger fraud indicator).
+
+`score_report` collapses those overlapping check-hits into one row
+per source transaction and assigns each a 0-100 risk score by
+summing the weights of the checks that fired. The result is a
+proper triage queue: sort by score descending, look at the top N,
+send the rest to bulk review. This is the model real audit tools
+(ACL, IDEA, Wolters Kluwer) use, and it's the fix for the "6,222
+rows flagged - which ones do I look at?" problem the raw report
+has on wide real-world CSVs.
+
+Reason codes: every scored row carries a `reasons` field listing
+the check names that fired. Downstream (AI summary, dashboard
+Findings tab) uses those to explain the score.
+"""
+import logging
+from typing import Iterable
+
+import pandas as pd
+
+from auris.config import DEFAULT_CONFIG, RiskConfig
+
+logger = logging.getLogger("auris")
+
+# Maps the risk_type string produced by each check function to the
+# corresponding weight attribute on RiskConfig. Keeps the check
+# functions themselves unaware of scoring.
+_RISK_TYPE_TO_WEIGHT_FIELD: dict[str, str] = {
+    "Duplicate": "duplicate_weight",
+    "Anomaly": "anomaly_weight",
+    "Amount Deviation": "deviation_weight",
+    "Missing Data": "missing_weight",
+    "High Frequency": "frequency_weight",
+    "ML Anomaly": "ml_weight",
+}
+
+_MAX_SCORE = 100.0
+
+
+def _weight_for(risk_type: str, config: RiskConfig) -> float:
+    """Look up the configured weight for a given risk_type string."""
+    field = _RISK_TYPE_TO_WEIGHT_FIELD.get(risk_type)
+    if field is None:
+        logger.warning("unknown risk_type '%s'; treating as zero-weight.", risk_type)
+        return 0.0
+    return float(getattr(config, field, 0.0))
+
+
+def score_report(
+    report: pd.DataFrame,
+    config: RiskConfig = DEFAULT_CONFIG,
+) -> pd.DataFrame:
+    """Collapse overlapping check-hits into one scored row per source transaction.
+
+    Given the concatenated report from all six risk checks, return a
+    new DataFrame where:
+
+    - Each source row (identified by `invoice_id`) appears exactly once.
+    - `risk_score` (0 to 100) is the sum of the weights of the checks
+      that fired on that row, capped at 100.
+    - `reasons` is a sorted list of the risk_type names that fired.
+    - Rows are sorted by `risk_score` descending, so the caller gets a
+      ready-made triage queue.
+
+    Rows without a usable `invoice_id` are kept unaggregated (each
+    check-hit becomes its own scored row) so no data is silently
+    lost, but they still get a `risk_score` and `reasons` field.
+
+    Empty input returns an empty DataFrame with the new columns
+    present so downstream code can rely on them existing.
+    """
+    if report is None or report.empty:
+        return pd.DataFrame(columns=list(getattr(report, "columns", [])) + ["risk_score", "reasons"])
+
+    if "risk_type" not in report.columns:
+        raise ValueError("report must include a 'risk_type' column for scoring.")
+
+    working = report.copy()
+    working["_weight"] = working["risk_type"].map(
+        lambda rt: _weight_for(rt, config)
+    ).astype(float)
+
+    # Rows without invoice_id are aggregated by their DataFrame index instead
+    # (each row becomes its own group), so they still get a score.
+    if "invoice_id" not in working.columns:
+        logger.warning(
+            "report has no 'invoice_id' column; scoring per row without dedup."
+        )
+        working["risk_score"] = working["_weight"].clip(upper=_MAX_SCORE)
+        working["reasons"] = working["risk_type"].apply(lambda rt: [rt])
+        result = working.drop(columns=["_weight"])
+        return result.sort_values("risk_score", ascending=False).reset_index(drop=True)
+
+    # Split rows with and without invoice_id.
+    has_id = working["invoice_id"].notna()
+    with_id = working.loc[has_id]
+    without_id = working.loc[~has_id]
+
+    scored_parts: list[pd.DataFrame] = []
+
+    if not with_id.empty:
+        grouped = with_id.groupby("invoice_id", sort=False, dropna=False)
+        first_rows = grouped.first().drop(columns=["_weight"], errors="ignore")
+        scores = grouped["_weight"].sum().clip(upper=_MAX_SCORE)
+        reasons = grouped["risk_type"].agg(lambda types: sorted(set(types)))
+        aggregated = first_rows.assign(
+            risk_score=scores,
+            reasons=reasons,
+        ).reset_index()
+        scored_parts.append(aggregated)
+
+    if not without_id.empty:
+        no_id = without_id.copy()
+        no_id["risk_score"] = no_id["_weight"].clip(upper=_MAX_SCORE)
+        no_id["reasons"] = no_id["risk_type"].apply(lambda rt: [rt])
+        no_id = no_id.drop(columns=["_weight"])
+        scored_parts.append(no_id)
+
+    if not scored_parts:
+        empty = working.drop(columns=["_weight", "risk_type"], errors="ignore").iloc[0:0].copy()
+        empty["risk_score"] = pd.Series(dtype=float)
+        empty["reasons"] = pd.Series(dtype=object)
+        return empty
+
+    result = pd.concat(scored_parts, ignore_index=True)
+
+    # Drop the now-redundant risk_type column: identity is in `reasons`.
+    if "risk_type" in result.columns:
+        result = result.drop(columns=["risk_type"])
+
+    logger.info(
+        "scored %d unique rows (from %d check-hits); "
+        "top score=%.1f, median=%.1f",
+        len(result), len(report),
+        float(result["risk_score"].max()) if not result.empty else 0.0,
+        float(result["risk_score"].median()) if not result.empty else 0.0,
+    )
+
+    return result.sort_values("risk_score", ascending=False).reset_index(drop=True)
+
+
+def top_n_by_score(scored: pd.DataFrame, n: int = 20) -> pd.DataFrame:
+    """Return the top N rows by risk_score. Assumes `scored` is already sorted."""
+    if scored is None or scored.empty:
+        return scored
+    return scored.head(n)
+
+
+def format_reasons(reasons: Iterable[str]) -> str:
+    """Format a reasons list for display or CSV export."""
+    return "; ".join(reasons) if reasons else ""

--- a/src/auris/summarize.py
+++ b/src/auris/summarize.py
@@ -29,6 +29,7 @@ logger = logging.getLogger("auris")
 
 _TOP_N_PER_TYPE = 5
 _TOP_N_OVERLAP_VENDORS = 10
+_TOP_N_BY_SCORE = 15
 _EMPTY_REPORT_MESSAGE = (
     "# AuRIS Risk Summary\n\n"
     "No risks were detected in the analysed transactions. "
@@ -79,7 +80,36 @@ FORMATTING RULES. Follow these strictly:
 Do not include preamble, closing notes, or meta commentary about the report itself."""
 
 
-def _build_prompt(report: pd.DataFrame) -> str:
+def _build_scored_section(scored: pd.DataFrame) -> list[str]:
+    """Build the "top N by risk score" section from a scored DataFrame.
+
+    Included in the prompt only when the caller passes a scored report.
+    Gives the model a ranked triage queue to prioritise its priority
+    actions instead of guessing from top-by-amount rows.
+    """
+    if scored is None or scored.empty or "risk_score" not in scored.columns:
+        return []
+    sections = ["# Top rows by risk score (triage queue, highest first)"]
+    top = scored.head(_TOP_N_BY_SCORE)
+    for _, row in top.iterrows():
+        vendor = row.get("vendor", "unknown")
+        amount = row.get("amount", "n/a")
+        date = row.get("date", "n/a")
+        score = float(row.get("risk_score", 0.0))
+        reasons = row.get("reasons", [])
+        if isinstance(reasons, (list, tuple, set)):
+            reasons_str = ", ".join(reasons)
+        else:
+            reasons_str = str(reasons)
+        sections.append(
+            f"- score={score:.0f}/100, vendor={vendor}, amount={amount}, "
+            f"date={date}, checks_fired=[{reasons_str}]"
+        )
+    sections.append("")
+    return sections
+
+
+def _build_prompt(report: pd.DataFrame, scored: pd.DataFrame | None = None) -> str:
     """Build a structured user-message body: aggregates, overlaps, then top rows per type."""
     sections: list[str] = []
 
@@ -151,6 +181,10 @@ def _build_prompt(report: pd.DataFrame) -> str:
             sections.append(f"- vendor={vendor}, amount={amount}, date={date}")
         sections.append("")
 
+    # Optional Level 2 scoring section: adds the ranked triage queue so the
+    # model's Priority Actions can name specific high-scoring rows directly.
+    sections.extend(_build_scored_section(scored))
+
     return "\n".join(sections).strip()
 
 
@@ -158,12 +192,18 @@ def summarize_risks(
     report: pd.DataFrame,
     config: RiskConfig = DEFAULT_CONFIG,
     client: Optional[object] = None,
+    scored: Optional[pd.DataFrame] = None,
 ) -> str:
     """Generate a Markdown executive summary of the risk report via Groq.
 
     Returns a canned no-risk message and does not hit the API when the
     report is empty. Raises RuntimeError if `GROQ_API_KEY` is unset.
     `client` is an optional pre-built Groq client, useful for tests.
+
+    If `scored` is passed (a DataFrame produced by
+    `auris.scoring.score_report`), an extra "Top rows by risk score"
+    section is added to the prompt so the model's Priority Actions can
+    directly reference the ranked triage queue.
     """
     if report is None or report.empty:
         logger.info("risk report is empty; skipping API call.")
@@ -184,10 +224,11 @@ def summarize_risks(
         from groq import Groq
         client = Groq()
 
-    user_prompt = _build_prompt(report)
+    user_prompt = _build_prompt(report, scored=scored)
     logger.info(
-        "requesting AI summary: model=%s, max_tokens=%d, prompt_chars=%d",
+        "requesting AI summary: model=%s, max_tokens=%d, prompt_chars=%d, scored=%s",
         config.summary_model, config.summary_max_tokens, len(user_prompt),
+        "yes" if scored is not None and not scored.empty else "no",
     )
 
     response = client.chat.completions.create(

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,136 @@
+"""Tests for the Level 2 risk-scoring engine."""
+import pandas as pd
+import pytest
+
+from auris.config import RiskConfig
+from auris.scoring import (
+    _MAX_SCORE,
+    _weight_for,
+    format_reasons,
+    score_report,
+    top_n_by_score,
+)
+
+
+@pytest.fixture
+def overlapping_report() -> pd.DataFrame:
+    """A report where two invoice_ids fire multiple checks and one fires just once."""
+    return pd.DataFrame([
+        # invoice 100: flagged by Duplicate + Anomaly + ML Anomaly (25 + 20 + 20 = 65)
+        {"invoice_id": 100, "vendor": "A", "amount": 5000.0, "date": "2025-01-01", "risk_type": "Duplicate"},
+        {"invoice_id": 100, "vendor": "A", "amount": 5000.0, "date": "2025-01-01", "risk_type": "Anomaly"},
+        {"invoice_id": 100, "vendor": "A", "amount": 5000.0, "date": "2025-01-01", "risk_type": "ML Anomaly"},
+        # invoice 200: flagged by Missing Data only (10)
+        {"invoice_id": 200, "vendor": "B", "amount": None, "date": "2025-01-02", "risk_type": "Missing Data"},
+        # invoice 300: flagged by every check (25 + 20 + 15 + 10 + 10 + 20 = 100)
+        {"invoice_id": 300, "vendor": "C", "amount": 9999.0, "date": "2025-01-03", "risk_type": "Duplicate"},
+        {"invoice_id": 300, "vendor": "C", "amount": 9999.0, "date": "2025-01-03", "risk_type": "Anomaly"},
+        {"invoice_id": 300, "vendor": "C", "amount": 9999.0, "date": "2025-01-03", "risk_type": "Amount Deviation"},
+        {"invoice_id": 300, "vendor": "C", "amount": 9999.0, "date": "2025-01-03", "risk_type": "Missing Data"},
+        {"invoice_id": 300, "vendor": "C", "amount": 9999.0, "date": "2025-01-03", "risk_type": "High Frequency"},
+        {"invoice_id": 300, "vendor": "C", "amount": 9999.0, "date": "2025-01-03", "risk_type": "ML Anomaly"},
+    ])
+
+
+def test_score_report_deduplicates_by_invoice_id(overlapping_report: pd.DataFrame) -> None:
+    """Overlapping check-hits on the same invoice collapse into one scored row."""
+    scored = score_report(overlapping_report, RiskConfig())
+    assert set(scored["invoice_id"]) == {100, 200, 300}
+    assert len(scored) == 3
+
+
+def test_score_report_sums_weights_and_lists_reasons(overlapping_report: pd.DataFrame) -> None:
+    """A row's score is the sum of its contributing check weights; reasons list them."""
+    scored = score_report(overlapping_report, RiskConfig()).set_index("invoice_id")
+
+    assert scored.loc[100, "risk_score"] == pytest.approx(65.0)  # 25 + 20 + 20
+    assert set(scored.loc[100, "reasons"]) == {"Duplicate", "Anomaly", "ML Anomaly"}
+
+    assert scored.loc[200, "risk_score"] == pytest.approx(10.0)
+    assert scored.loc[200, "reasons"] == ["Missing Data"]
+
+    assert scored.loc[300, "risk_score"] == pytest.approx(100.0)  # sum = 100
+    assert len(scored.loc[300, "reasons"]) == 6
+
+
+def test_score_report_caps_score_at_100(overlapping_report: pd.DataFrame) -> None:
+    """With inflated weights, a row's score still tops out at 100."""
+    config = RiskConfig(
+        duplicate_weight=100, anomaly_weight=100, deviation_weight=100,
+        missing_weight=100, frequency_weight=100, ml_weight=100,
+    )
+    scored = score_report(overlapping_report, config).set_index("invoice_id")
+    assert scored["risk_score"].max() <= _MAX_SCORE
+    # invoice 300 fires all 6 checks, would sum to 600 without the cap.
+    assert scored.loc[300, "risk_score"] == pytest.approx(_MAX_SCORE)
+
+
+def test_score_report_sorts_descending_by_score(overlapping_report: pd.DataFrame) -> None:
+    """Output is a ready-made triage queue: highest score first."""
+    scored = score_report(overlapping_report, RiskConfig())
+    scores = scored["risk_score"].tolist()
+    assert scores == sorted(scores, reverse=True)
+    assert scored.iloc[0]["invoice_id"] == 300  # 100 wins
+    assert scored.iloc[-1]["invoice_id"] == 200  # 10 loses
+
+
+def test_score_report_respects_custom_weights() -> None:
+    """Overriding weights on RiskConfig changes the resulting scores."""
+    report = pd.DataFrame([
+        {"invoice_id": 1, "vendor": "X", "amount": 100.0, "date": "2025-01-01", "risk_type": "Duplicate"},
+    ])
+    weak_dupes = RiskConfig(duplicate_weight=5.0)
+    strong_dupes = RiskConfig(duplicate_weight=80.0)
+    assert score_report(report, weak_dupes).iloc[0]["risk_score"] == pytest.approx(5.0)
+    assert score_report(report, strong_dupes).iloc[0]["risk_score"] == pytest.approx(80.0)
+
+
+def test_score_report_handles_empty_input() -> None:
+    """An empty report round-trips cleanly with the new columns present."""
+    empty = pd.DataFrame(columns=["invoice_id", "vendor", "amount", "date", "risk_type"])
+    result = score_report(empty, RiskConfig())
+    assert "risk_score" in result.columns
+    assert "reasons" in result.columns
+    assert result.empty
+
+
+def test_score_report_warns_on_unknown_risk_type(caplog: pytest.LogCaptureFixture) -> None:
+    """A risk_type not in the weight map contributes 0 with a warning."""
+    report = pd.DataFrame([
+        {"invoice_id": 1, "vendor": "X", "amount": 100.0, "date": "2025-01-01", "risk_type": "Mystery Type"},
+    ])
+    caplog.set_level("WARNING", logger="auris")
+    result = score_report(report, RiskConfig())
+    assert result.iloc[0]["risk_score"] == pytest.approx(0.0)
+    assert any("Mystery Type" in rec.message for rec in caplog.records)
+
+
+def test_score_report_falls_back_when_no_invoice_id(overlapping_report: pd.DataFrame) -> None:
+    """Missing invoice_id column: each check-hit becomes its own scored row."""
+    without_id = overlapping_report.drop(columns=["invoice_id"])
+    scored = score_report(without_id, RiskConfig())
+    assert len(scored) == len(without_id)
+    assert "risk_score" in scored.columns
+    # First row should be one of the high-weight checks (Duplicate, Anomaly, or ML).
+    assert scored.iloc[0]["risk_score"] >= 20.0
+
+
+def test_top_n_by_score_returns_head(overlapping_report: pd.DataFrame) -> None:
+    """top_n_by_score returns the first N rows of an already-sorted DataFrame."""
+    scored = score_report(overlapping_report, RiskConfig())
+    top = top_n_by_score(scored, n=2)
+    assert len(top) == 2
+    assert list(top["invoice_id"]) == [300, 100]  # score 100, then 65
+
+
+def test_weight_for_returns_configured_value() -> None:
+    """_weight_for looks up the correct weight attribute on the config."""
+    config = RiskConfig(duplicate_weight=42.0)
+    assert _weight_for("Duplicate", config) == 42.0
+    assert _weight_for("Unknown", config) == 0.0
+
+
+def test_format_reasons_joins_with_semicolons() -> None:
+    """format_reasons produces a CSV-safe display string."""
+    assert format_reasons(["Duplicate", "Anomaly"]) == "Duplicate; Anomaly"
+    assert format_reasons([]) == ""


### PR DESCRIPTION
## Why

Every complaint in this session's transcript has come back to the same thing: raw check output is a flat list, not a ranked queue. Even after tightening thresholds and deduplicating overlapping check-hits, aurisnow.streamlit.app still shows a big number ("6,222 rows flagged") with no answer to *"which do I look at first?"*.

Level 2 fixes that. Every unique source row gets a 0-100 risk score aggregating the weights of the checks that fired, plus a `reasons` list. The dashboard's Findings tab is now a triage queue sorted by score. The AI summary consumes the top-scored rows for its Priority Actions. This is the model real audit tools (ACL, IDEA, Wolters Kluwer) use.

## What ships

- **New \`src/auris/scoring.py\`.** \`score_report(report, config)\` deduplicates by \`invoice_id\`, sums per-check weights (capped at 100), preserves a sorted list of contributing \`reasons\`, returns a sort-by-score-descending DataFrame. Also \`top_n_by_score()\` and \`format_reasons()\` helpers.
- **\`RiskConfig\` gains six weight fields** summing to 100 by default: Duplicate 25, Anomaly 20, Amount Deviation 15, Missing 10, Frequency 10, ML 20. Rationale in the docstring.
- **CLI writes \`risks_scored.csv\`** alongside \`risks_report.csv\`. The AI summary receives the scored view.
- **AI summary layer** (\`summarize_risks\`) gains an optional \`scored=\` kwarg. When provided, the prompt now includes a "Top rows by risk score" section with the top 15 rows' score, vendor, amount, date, and list of checks. Model can name specific high-scoring rows in Priority Actions instead of guessing from top-by-amount.
- **Dashboard changes:**
  - Pipeline status streams a "Scoring rows across all checks" stage with top and median score.
  - Metric row gains a **"Priority queue"** tile counting rows with score >= 50 (typically 3+ checks fired).
  - **Findings tab is now the scored triage queue.** Sorted by score descending. Minimum-score slider (defaults to 30). Per-check filter based on the \`reasons\` column so users can still slice by check type.
  - CSV export renamed to \`risks_scored.csv\` with reasons flattened to a semicolon-separated string.

## End-to-end run on the bundled NASA sample

    raw report:          2,036 check-hits
    scored:              1,660 unique rows
    top score:           65 (Anomaly + Deviation + Frequency + ML on Caltech)
    priority (>= 50):    a sensible triage pool (was: no ranking at all)

## Tests

Total: **52 tests** (was 41). New \`tests/test_scoring.py\` with 11 local tests covering dedup, weight summation, score cap, sort order, custom overrides, empty input, unknown-risk warnings, missing-invoice-id fallback, and helpers.

## Test plan
- [ ] CI: pytest matrix green on Python 3.10 / 3.11 / 3.12, all 52 tests still passing.
- [ ] After Streamlit Cloud redeploy at aurisnow.streamlit.app:
  - [ ] "Priority queue" metric tile appears with a sensible count.
  - [ ] Findings tab shows rows sorted by score with the reasons column visible.
  - [ ] Minimum-score slider filters the queue.
  - [ ] AI Summary output references specific high-scoring rows in its Priority Actions section.
  - [ ] Downloaded \`risks_scored.csv\` has \`risk_score\` and \`reasons\` columns.