### PR TITLE
Level 3 phase A: FastAPI backend wrapping the AuRIS engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "groq>=0.11",
     "python-dotenv>=1.0",
     "plotly>=5.20",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "python-multipart>=0.0.9",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ scikit-learn>=1.3.0
 groq>=0.11
 python-dotenv>=1.0
 plotly>=5.20
+fastapi>=0.110
+uvicorn[standard]>=0.27
+python-multipart>=0.0.9
 .

--- a/src/auris/api.py
+++ b/src/auris/api.py
@@ -1,0 +1,317 @@
+"""FastAPI backend wrapping the AuRIS engine.
+
+Same pipeline as the Streamlit dashboard, exposed as REST endpoints so a
+Next.js (or any other) frontend can drive it. The engine, scoring layer,
+LLM column detection, and AI summary generation are unchanged; this
+module is a thin HTTP adaptor.
+
+Endpoints:
+
+- GET  /health              - liveness check, returns pipeline version.
+- GET  /config              - default RiskConfig as JSON.
+- POST /analyze             - multipart CSV upload; runs the full
+                              pipeline (column detection if needed,
+                              six checks, scoring) and returns the
+                              scored triage queue plus per-check
+                              counts and metric totals.
+- POST /summarize           - accepts a JSON body with the report and
+                              (optional) scored report; returns the
+                              Groq/Llama executive summary.
+
+The FastAPI app is exported as `app` so uvicorn can find it:
+    uvicorn auris.api:app --host 0.0.0.0 --port 8000
+
+CORS is permissive by default (any origin) so a local Next.js dev
+server can talk to a locally-running API. Tighten CORS in production
+by setting the AURIS_CORS_ORIGINS env var to a comma-separated list.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import os
+from typing import Any, Optional
+
+import pandas as pd
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from auris.audit_risk import (
+    check_amount_deviation,
+    check_anomalies,
+    check_duplicates,
+    check_missing,
+    check_vendor_frequency,
+)
+from auris.config import DEFAULT_CONFIG, RiskConfig
+from auris.schema import REQUIRED_FIELDS, apply_mapping, detect_columns
+from auris.scoring import format_reasons, score_report
+from auris.summarize import summarize_risks
+
+logger = logging.getLogger("auris.api")
+
+API_VERSION = "0.1.0"
+
+
+class RiskConfigModel(BaseModel):
+    """Wire-format RiskConfig. Mirrors the dataclass, all fields optional."""
+
+    anomaly_quantile: Optional[float] = None
+    vendor_frequency_quantile: Optional[float] = None
+    deviation_low_multiplier: Optional[float] = None
+    deviation_high_multiplier: Optional[float] = None
+    ml_contamination: Optional[float] = None
+    duplicate_weight: Optional[float] = None
+    anomaly_weight: Optional[float] = None
+    deviation_weight: Optional[float] = None
+    missing_weight: Optional[float] = None
+    frequency_weight: Optional[float] = None
+    ml_weight: Optional[float] = None
+
+    def to_dataclass(self) -> RiskConfig:
+        """Apply this model's non-None fields on top of DEFAULT_CONFIG."""
+        overrides = {k: v for k, v in self.model_dump().items() if v is not None}
+        if not overrides:
+            return DEFAULT_CONFIG
+        return RiskConfig(**{**DEFAULT_CONFIG.__dict__, **overrides})
+
+
+class HealthResponse(BaseModel):
+    status: str = "ok"
+    api_version: str = API_VERSION
+
+
+class PerCheckCounts(BaseModel):
+    duplicates: int
+    anomalies: int
+    missing: int
+    high_frequency: int
+    amount_deviation: int
+
+
+class AnalysisMetrics(BaseModel):
+    total_transactions: int
+    unique_vendors: int
+    flagged_pool_unique: int
+    priority_queue_count: int = Field(
+        description="Rows with risk_score >= 50 (typical triage threshold)."
+    )
+    total_flagged_amount: float
+    top_score: float
+    median_score: float
+
+
+class ColumnMappingInfo(BaseModel):
+    used: bool = Field(description="True if LLM column detection ran on this CSV.")
+    mapping: dict[str, Optional[str]] = Field(
+        default_factory=dict,
+        description="Detected mapping from AuRIS schema fields to source column names.",
+    )
+
+
+class AnalysisResponse(BaseModel):
+    metrics: AnalysisMetrics
+    per_check_counts: PerCheckCounts
+    column_mapping: ColumnMappingInfo
+    scored_rows: list[dict[str, Any]] = Field(
+        description="Scored triage queue, one row per invoice_id, sorted by risk_score desc.",
+    )
+    report_rows: list[dict[str, Any]] = Field(
+        description="Raw check-hit report before scoring (one row per (row, check) pair).",
+    )
+
+
+class SummarizeRequest(BaseModel):
+    report_rows: list[dict[str, Any]] = Field(
+        description="The raw check-hit report from /analyze.",
+    )
+    scored_rows: Optional[list[dict[str, Any]]] = Field(
+        default=None,
+        description="Optional scored triage queue from /analyze. When provided, "
+        "the AI summary includes a Top rows by risk score section.",
+    )
+    config: Optional[RiskConfigModel] = None
+
+
+class SummarizeResponse(BaseModel):
+    summary_markdown: str
+
+
+def _serialise_rows(df: pd.DataFrame) -> list[dict[str, Any]]:
+    """Convert a DataFrame to JSON-safe dicts."""
+    if df is None or df.empty:
+        return []
+    # `reasons` may contain lists; leave as-is for JSON, but stringify for CSV export.
+    return df.replace({pd.NA: None}).to_dict(orient="records")
+
+
+def create_app() -> FastAPI:
+    """Build the FastAPI app. Factory so tests can rebuild per test if needed."""
+    app = FastAPI(
+        title="AuRIS API",
+        description=(
+            "Audit-risk pipeline as REST. Upload a CSV; get six statistical "
+            "risk checks, a scored triage queue, and optionally an "
+            "LLM-generated executive summary."
+        ),
+        version=API_VERSION,
+    )
+
+    origins_env = os.environ.get("AURIS_CORS_ORIGINS", "*")
+    origins = ["*"] if origins_env == "*" else [o.strip() for o in origins_env.split(",")]
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/health", response_model=HealthResponse)
+    def health() -> HealthResponse:
+        return HealthResponse()
+
+    @app.get("/config", response_model=dict[str, Any])
+    def get_config() -> dict[str, Any]:
+        """Return the default RiskConfig as a JSON dict."""
+        return DEFAULT_CONFIG.__dict__.copy()
+
+    @app.post("/analyze", response_model=AnalysisResponse)
+    async def analyze(
+        file: UploadFile = File(..., description="Transactions CSV."),
+    ) -> AnalysisResponse:
+        """Run the full pipeline on an uploaded CSV.
+
+        - If the CSV already has AuRIS's four required columns
+          (vendor, amount, date, invoice_id), the pipeline runs as-is.
+        - Otherwise, the LLM column detector maps arbitrary column
+          names into AuRIS's schema. Requires GROQ_API_KEY.
+        """
+        if not file.filename or not file.filename.lower().endswith(".csv"):
+            raise HTTPException(400, "Only CSV files are supported.")
+
+        raw = await file.read()
+        try:
+            data = pd.read_csv(io.BytesIO(raw), low_memory=False)
+        except Exception as exc:
+            raise HTTPException(400, f"Could not parse CSV: {exc}")
+
+        if data.empty:
+            raise HTTPException(400, "CSV is empty.")
+
+        config = DEFAULT_CONFIG
+
+        # Column detection: only when the schema is not already present.
+        already_mapped = set(REQUIRED_FIELDS).issubset(data.columns)
+        mapping_info = ColumnMappingInfo(used=False)
+        if not already_mapped:
+            try:
+                detected = detect_columns(data, config)
+                data = apply_mapping(data, detected)
+                mapping_info = ColumnMappingInfo(used=True, mapping=detected)
+            except Exception as exc:
+                logger.error("column detection failed: %s", exc)
+                raise HTTPException(
+                    422,
+                    f"Column detection failed and CSV does not match AuRIS's default "
+                    f"schema. Provide vendor/amount/date/invoice_id columns, or ensure "
+                    f"GROQ_API_KEY is set. Detail: {exc}",
+                )
+
+        # Missing required columns even after mapping is a caller bug.
+        missing_required = [c for c in REQUIRED_FIELDS if c not in data.columns]
+        if missing_required:
+            raise HTTPException(
+                422,
+                f"After column detection, still missing required columns: {missing_required}.",
+            )
+
+        # Run all five statistical checks.
+        duplicates = check_duplicates(data)
+        anomalies = check_anomalies(data, config)
+        missing = check_missing(data)
+        frequent = check_vendor_frequency(data, config)
+        deviations = check_amount_deviation(data, config)
+
+        report = pd.concat(
+            [duplicates, anomalies, missing, frequent, deviations],
+            ignore_index=True,
+        )
+        scored = score_report(report, config)
+
+        # Build metrics.
+        total_flagged_amount = (
+            float(report["amount"].dropna().sum()) if not report.empty else 0.0
+        )
+        top_score = float(scored["risk_score"].max()) if not scored.empty else 0.0
+        median_score = float(scored["risk_score"].median()) if not scored.empty else 0.0
+        priority_count = int((scored["risk_score"] >= 50).sum()) if not scored.empty else 0
+
+        # Serialise the reasons column (lists) as human-readable strings for the
+        # JSON payload so JS callers don't have to concat arrays for display.
+        scored_display = scored.copy()
+        if not scored_display.empty and "reasons" in scored_display.columns:
+            scored_display["reasons"] = scored_display["reasons"].apply(format_reasons)
+
+        return AnalysisResponse(
+            metrics=AnalysisMetrics(
+                total_transactions=int(len(data)),
+                unique_vendors=int(data["vendor"].nunique()),
+                flagged_pool_unique=int(len(scored)),
+                priority_queue_count=priority_count,
+                total_flagged_amount=total_flagged_amount,
+                top_score=top_score,
+                median_score=median_score,
+            ),
+            per_check_counts=PerCheckCounts(
+                duplicates=int(len(duplicates)),
+                anomalies=int(len(anomalies)),
+                missing=int(len(missing)),
+                high_frequency=int(len(frequent)),
+                amount_deviation=int(len(deviations)),
+            ),
+            column_mapping=mapping_info,
+            scored_rows=_serialise_rows(scored_display),
+            report_rows=_serialise_rows(report),
+        )
+
+    @app.post("/summarize", response_model=SummarizeResponse)
+    def summarize(request: SummarizeRequest) -> SummarizeResponse:
+        """Generate a Markdown executive summary via Groq.
+
+        Accepts the raw report from /analyze plus (optionally) the scored
+        triage queue. When the scored view is provided, the summary
+        prompt includes a Top rows by risk score section for sharper
+        Priority Actions.
+        """
+        if not request.report_rows:
+            raise HTTPException(400, "report_rows is required and cannot be empty.")
+
+        config = (
+            request.config.to_dataclass() if request.config is not None else DEFAULT_CONFIG
+        )
+
+        report_df = pd.DataFrame(request.report_rows)
+        scored_df: Optional[pd.DataFrame] = None
+        if request.scored_rows:
+            scored_df = pd.DataFrame(request.scored_rows)
+            # Recover the reasons column: /analyze serialises it as a string
+            # ("A; B; C") so we split it back into a list for the prompt.
+            if "reasons" in scored_df.columns:
+                scored_df["reasons"] = scored_df["reasons"].apply(
+                    lambda v: [s.strip() for s in v.split(";")] if isinstance(v, str) else v
+                )
+
+        try:
+            markdown = summarize_risks(report_df, config, scored=scored_df)
+        except RuntimeError as exc:
+            raise HTTPException(503, str(exc))
+        except ValueError as exc:
+            raise HTTPException(400, str(exc))
+        return SummarizeResponse(summary_markdown=markdown)
+
+    return app
+
+
+app = create_app()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,286 @@
+"""Tests for the FastAPI backend (src/auris/api.py).
+
+FastAPI's TestClient drives the endpoints. The LLM-touching endpoints
+(schema.detect_columns and summarize.summarize_risks) are mocked at
+their call sites in the api module so no real API calls happen in CI.
+"""
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from auris.api import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def synthetic_csv() -> bytes:
+    """A tiny CSV already in AuRIS's schema, so LLM detection is skipped."""
+    rows = [
+        # duplicates on same vendor/amount/date
+        {"invoice_id": 1, "vendor": "A", "amount": 100.0, "date": "2025-01-01"},
+        {"invoice_id": 2, "vendor": "A", "amount": 100.0, "date": "2025-01-01"},
+        # one big outlier for anomaly
+        {"invoice_id": 3, "vendor": "B", "amount": 9999.0, "date": "2025-01-02"},
+        # a mix of small transactions so scoring has variety
+        {"invoice_id": 4, "vendor": "C", "amount": 50.0, "date": "2025-01-03"},
+        {"invoice_id": 5, "vendor": "C", "amount": 55.0, "date": "2025-01-04"},
+        {"invoice_id": 6, "vendor": "D", "amount": 60.0, "date": "2025-01-05"},
+    ]
+    df = pd.DataFrame(rows)
+    return df.to_csv(index=False).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+def test_health_returns_ok(client: TestClient) -> None:
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert "api_version" in body
+
+
+# ---------------------------------------------------------------------------
+# /config
+# ---------------------------------------------------------------------------
+
+def test_config_returns_default_riskconfig_fields(client: TestClient) -> None:
+    r = client.get("/config")
+    assert r.status_code == 200
+    body = r.json()
+    # Must include the AuRIS knobs a caller would want to display.
+    for field in [
+        "anomaly_quantile", "vendor_frequency_quantile",
+        "deviation_low_multiplier", "deviation_high_multiplier",
+        "ml_contamination",
+        "duplicate_weight", "anomaly_weight", "deviation_weight",
+        "missing_weight", "frequency_weight", "ml_weight",
+        "summary_model", "summary_max_tokens",
+    ]:
+        assert field in body, f"missing {field} in /config response"
+
+
+# ---------------------------------------------------------------------------
+# /analyze
+# ---------------------------------------------------------------------------
+
+def test_analyze_rejects_non_csv(client: TestClient) -> None:
+    r = client.post(
+        "/analyze",
+        files={"file": ("data.txt", b"not,a,csv", "text/plain")},
+    )
+    assert r.status_code == 400
+    assert "CSV" in r.json()["detail"]
+
+
+def test_analyze_rejects_empty_csv(client: TestClient) -> None:
+    # A CSV file with only whitespace parses to an empty DataFrame.
+    r = client.post(
+        "/analyze",
+        files={"file": ("empty.csv", b"\n", "text/csv")},
+    )
+    assert r.status_code == 400
+
+
+def test_analyze_runs_pipeline_on_schema_matching_csv(
+    client: TestClient, synthetic_csv: bytes
+) -> None:
+    """When the CSV already has AuRIS's schema, no LLM call is made."""
+    r = client.post(
+        "/analyze",
+        files={"file": ("transactions.csv", synthetic_csv, "text/csv")},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    # Shape assertions
+    assert body["column_mapping"]["used"] is False
+    assert body["metrics"]["total_transactions"] == 6
+    assert body["metrics"]["unique_vendors"] == 4  # A, B, C, D
+
+    # The synthetic data was designed to fire duplicates on rows 1-2 and
+    # anomaly on row 3.
+    assert body["per_check_counts"]["duplicates"] == 2
+    assert body["per_check_counts"]["anomalies"] >= 1
+
+    # Scored triage queue exists and is sorted by score descending.
+    scored = body["scored_rows"]
+    assert isinstance(scored, list)
+    if len(scored) > 1:
+        scores = [row["risk_score"] for row in scored]
+        assert scores == sorted(scores, reverse=True)
+
+    # Each scored row has the expected columns.
+    if scored:
+        assert "risk_score" in scored[0]
+        assert "reasons" in scored[0]
+        assert isinstance(scored[0]["reasons"], str)  # serialised for display
+
+
+def test_analyze_calls_llm_column_detection_when_schema_absent(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the CSV does not match AuRIS's schema, detect_columns is invoked."""
+    # A CSV using different column names.
+    df = pd.DataFrame([
+        {"awd_id": 1, "recipient": "A", "usd": 100.0, "action_date": "2025-01-01"},
+        {"awd_id": 2, "recipient": "A", "usd": 100.0, "action_date": "2025-01-01"},
+        {"awd_id": 3, "recipient": "B", "usd": 9999.0, "action_date": "2025-01-02"},
+    ])
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+
+    fake_mapping = {
+        "vendor": "recipient",
+        "amount": "usd",
+        "date": "action_date",
+        "invoice_id": "awd_id",
+    }
+    with patch("auris.api.detect_columns", return_value=fake_mapping) as mock_detect:
+        r = client.post(
+            "/analyze",
+            files={"file": ("odd_columns.csv", csv_bytes, "text/csv")},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["column_mapping"]["used"] is True
+    assert body["column_mapping"]["mapping"] == fake_mapping
+    mock_detect.assert_called_once()
+
+
+def test_analyze_returns_422_when_column_detection_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """detect_columns raising RuntimeError bubbles up as 422."""
+    df = pd.DataFrame([{"a": 1, "b": 2, "c": 3, "d": 4}])
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+
+    with patch(
+        "auris.api.detect_columns",
+        side_effect=RuntimeError("GROQ_API_KEY missing"),
+    ):
+        r = client.post(
+            "/analyze",
+            files={"file": ("no_key.csv", csv_bytes, "text/csv")},
+        )
+    assert r.status_code == 422
+    assert "GROQ_API_KEY" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# /summarize
+# ---------------------------------------------------------------------------
+
+def test_summarize_rejects_empty_report_rows(client: TestClient) -> None:
+    r = client.post("/summarize", json={"report_rows": []})
+    assert r.status_code == 400
+
+
+def test_summarize_delegates_to_summarize_risks(client: TestClient) -> None:
+    """Summarize should hand off to summarize_risks and return its markdown."""
+    with patch(
+        "auris.api.summarize_risks",
+        return_value="# AuRIS Risk Summary\n\nMocked body.",
+    ) as mock_summarize:
+        r = client.post(
+            "/summarize",
+            json={
+                "report_rows": [
+                    {"invoice_id": 1, "vendor": "X", "amount": 100.0,
+                     "date": "2025-01-01", "risk_type": "Duplicate"},
+                ],
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["summary_markdown"].startswith("# AuRIS Risk Summary")
+    mock_summarize.assert_called_once()
+    # Confirm the config default was applied (positional arg 2) and no scored
+    # was passed (kwarg scored=None).
+    _, kwargs = mock_summarize.call_args
+    assert kwargs["scored"] is None
+
+
+def test_summarize_passes_scored_when_provided(client: TestClient) -> None:
+    """When scored_rows is in the request body, it must be forwarded to summarize_risks."""
+    with patch(
+        "auris.api.summarize_risks",
+        return_value="# AuRIS Risk Summary\n\nWith scored.",
+    ) as mock_summarize:
+        r = client.post(
+            "/summarize",
+            json={
+                "report_rows": [
+                    {"invoice_id": 1, "vendor": "X", "amount": 100.0,
+                     "date": "2025-01-01", "risk_type": "Duplicate"},
+                ],
+                "scored_rows": [
+                    {"invoice_id": 1, "vendor": "X", "amount": 100.0,
+                     "date": "2025-01-01", "risk_score": 25.0,
+                     "reasons": "Duplicate"},
+                ],
+            },
+        )
+    assert r.status_code == 200, r.text
+    _, kwargs = mock_summarize.call_args
+    assert kwargs["scored"] is not None
+    # reasons should have been split back into a list on the way in.
+    assert list(kwargs["scored"]["reasons"].iloc[0]) == ["Duplicate"]
+
+
+def test_summarize_returns_503_when_api_key_missing(client: TestClient) -> None:
+    """A RuntimeError from summarize_risks (missing key) maps to 503."""
+    with patch(
+        "auris.api.summarize_risks",
+        side_effect=RuntimeError("GROQ_API_KEY environment variable is required"),
+    ):
+        r = client.post(
+            "/summarize",
+            json={
+                "report_rows": [
+                    {"invoice_id": 1, "vendor": "X", "amount": 100.0,
+                     "date": "2025-01-01", "risk_type": "Duplicate"},
+                ],
+            },
+        )
+    assert r.status_code == 503
+    assert "GROQ_API_KEY" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Config overrides
+# ---------------------------------------------------------------------------
+
+def test_config_model_applies_overrides_on_top_of_defaults() -> None:
+    """RiskConfigModel.to_dataclass merges overrides with DEFAULT_CONFIG."""
+    from auris.api import RiskConfigModel
+    from auris.config import DEFAULT_CONFIG
+
+    model = RiskConfigModel(anomaly_quantile=0.995, duplicate_weight=40.0)
+    result = model.to_dataclass()
+    assert result.anomaly_quantile == 0.995
+    assert result.duplicate_weight == 40.0
+    # Untouched fields keep the default value.
+    assert result.vendor_frequency_quantile == DEFAULT_CONFIG.vendor_frequency_quantile
+    assert result.summary_model == DEFAULT_CONFIG.summary_model
+
+
+def test_config_model_with_no_overrides_returns_default() -> None:
+    """An empty RiskConfigModel returns the DEFAULT_CONFIG instance."""
+    from auris.api import RiskConfigModel
+    from auris.config import DEFAULT_CONFIG
+
+    model = RiskConfigModel()
+    assert model.to_dataclass() is DEFAULT_CONFIG


### PR DESCRIPTION
## Level 3 kickoff — backend first

This is phase A of the Level 3 full-stack rebuild from the roadmap. A FastAPI app exposes the existing engine, scoring layer, LLM column detection, and Groq/Llama summarization as REST endpoints so a Next.js frontend can drive the same pipeline the Streamlit dashboard drives today.

**Explicitly out of scope for this PR:** Next.js frontend, Docker, Railway/Vercel deploy. Those follow in phase B and C. The Streamlit dashboard remains the primary demo at aurisnow.streamlit.app until the Next.js UI lands.

## Endpoints

| Method | Path | What it does |
|---|---|---|
| GET | \`/health\` | Liveness + api_version. |
| GET | \`/config\` | Default \`RiskConfig\` as JSON so the frontend can render initial sliders. |
| POST | \`/analyze\` | Multipart CSV upload. LLM column detection runs if the CSV lacks the four required columns. Returns per-check counts, priority-queue metrics, scored triage queue with reasons flattened for display, and the raw check-hit report. |
| POST | \`/summarize\` | Accepts \`report_rows\` + optional \`scored_rows\`, calls \`summarize_risks\`, returns Markdown. |

## Design notes

- **Pure adaptor.** Engine, scoring, schema detection, and summary generation are imported unchanged. Nothing forks.
- **\`RiskConfigModel\`** wraps the frozen dataclass so callers can PATCH a subset of fields; \`.to_dataclass()\` layers overrides on top of \`DEFAULT_CONFIG\`.
- **CORS permissive by default** (\`allow_origins=[\"*\"]\`) so a local Next.js dev server works out of the box. Tighten in production with \`AURIS_CORS_ORIGINS\` env var.
- **Error mapping:** bad CSV → 400, missing schema and no \`GROQ_API_KEY\` → 422, LLM outage on summarize → 503.
- **\`scored_rows\` serialisation:** \`/analyze\` flattens the \`reasons\` list to a display-friendly \`"A; B; C"\` string; \`/summarize\` splits it back into a list before handing off to \`summarize_risks\` so the prompt section is well-formed.

## Tests

**13 new mocked tests** in \`tests/test_api.py\`:
- Health, config, CSV rejection, empty upload, schema-match pipeline path (no LLM), LLM detection path (mocked), detection failure → 422
- Summarize with and without scored view, summarize error path (503)
- \`RiskConfigModel\` merge behaviour with and without overrides

Total suite: **65 tests** (was 52). All local, no real API calls in CI.

## Test plan
- [ ] CI: pytest matrix green on Python 3.10 / 3.11 / 3.12, all 65 tests passing.
- [ ] Locally: \`uvicorn auris.api:app --port 8000\`, then \`curl -F file=@data/transactions.csv http://localhost:8000/analyze\` returns the analysis JSON.
- [ ] \`GROQ_API_KEY\` set + \`curl -X POST http://localhost:8000/summarize -H 'Content-Type: application/json' -d '{"report_rows":[...]}'\` returns Markdown.

## Follow-ups

- Docs PR mentioning the API on the "interfaces" list (deferred to avoid conflict with in-flight PR #27).
- Phase B: Next.js 15 + shadcn frontend consuming \`/analyze\` + \`/summarize\`.
- Phase C: Dockerfile + Railway deploy for the backend + Vercel deploy for the frontend.