### PR TITLE
Fix: FastAPI backend auto-loads .env so uvicorn sees GROQ_API_KEY

### DIFF
--- a/src/auris/api.py
+++ b/src/auris/api.py
@@ -32,6 +32,14 @@ import logging
 import os
 from typing import Any, Optional
 
+# Load .env before importing anything that reads env vars (schema.py and
+# summarize.py both check GROQ_API_KEY at call time). Mirrors the pattern
+# used by src/auris/__main__.py and app.py so `uvicorn auris.api:app` picks
+# up the same .env file the CLI and Streamlit dashboard do.
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import pandas as pd
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware


### PR DESCRIPTION
## Bug

Running \`uvicorn auris.api:app --port 8000\` and uploading a CSV whose columns don't match AuRIS's default schema returns 422 with:

> Column detection failed and CSV does not match AuRIS's default schema. Provide vendor/amount/date/invoice_id columns, or ensure GROQ_API_KEY is set. Detail: GROQ_API_KEY environment variable is required for LLM column detection.

The user has \`.env\` at the repo root with \`GROQ_API_KEY=gsk_...\` already. The CLI and Streamlit dashboard both pick it up automatically. The FastAPI backend does not.

## Cause

\`src/auris/__main__.py\` (CLI) and \`app.py\` (Streamlit) both call \`load_dotenv()\` before importing the rest of the package. \`src/auris/api.py\` was created in #28 without that call, so anyone running \`uvicorn auris.api:app\` has to manually \`export GROQ_API_KEY=...\` in the shell every session.

This blocks the Next.js frontend from working end-to-end locally.

## Fix

One \`load_dotenv()\` call at the top of \`api.py\`, before importing \`schema.py\` or \`summarize.py\` (both check \`GROQ_API_KEY\` at call time). Same pattern the CLI and Streamlit entrypoints already use. \`python-dotenv\` is silent when \`.env\` is absent, so this is a no-op in CI and in production (Railway sets env vars directly).

## Test plan
- [ ] CI: pytest matrix green on Python 3.10 / 3.11 / 3.12, all 65 tests still passing.
- [ ] Locally with \`.env\` at repo root: \`uvicorn auris.api:app --port 8000\`, then upload a non-schema CSV (like \`data/usaspending_raw.csv\`) via the Next.js frontend; LLM column detection now succeeds and the analysis runs to completion.
- [ ] Locally without \`.env\`: same command still returns the same clear 422 with the "GROQ_API_KEY required" message.

## Merge order

Merge this **first**, then #29 (frontend). After both merge, \`aurisnow.streamlit.app\` is unchanged (Streamlit already loads .env); the local Next.js dev setup works end-to-end.